### PR TITLE
Add cpu offload

### DIFF
--- a/examples/bench_chat.py
+++ b/examples/bench_chat.py
@@ -18,26 +18,26 @@ if __name__ == "__main__":
         default=None,
         help="Run benchmark with a single prompt instead of prompt files",
     )
+    parser.add_argument(
+        "--cpu-offload",
+        action="store_true",
+        default=None,
+        dest="cpu_offload",
+        help="Enable CPU offload for MoE expert weights",
+    )
     args = parser.parse_args()
 
     checkpoint = get_model_with_checkpoint(args.checkpoint)
-    tool = HarmonyChatTool(checkpoint, reasoning_effort="high")
+    tool = HarmonyChatTool(checkpoint, reasoning_effort="high", cpu_offload=args.cpu_offload)
 
     if args.prompt:
         tool.print_system_info()
-        messages = tool.base_messages.copy()
-        token_begin = time.perf_counter()
-        stats = tool._benchmark_inference(args.prompt, messages)
-        elapsed = time.perf_counter() - token_begin
-        token_num = stats["generated_tokens"]
-        decode_time = stats["decode_time_s"]
-        prefill_time = stats["prefill_time_s"]
-        print(f"\nPrompt: {args.prompt}")
-        print(f"Generated: {token_num} tokens")
-        print(f"Decode TPS: {token_num / decode_time:.3f}" if decode_time > 0 else "Decode TPS: N/A")
-        print(f"E2E TPS: {token_num / elapsed:.3f}" if elapsed > 0 else "E2E TPS: N/A")
-        print(f"Prefill: {prefill_time * 1000:.1f} ms")
-        print(f"Decode: {decode_time * 1000:.1f} ms")
+        response = tool.single_inference(args.prompt, interactive=True)
+        stats = tool.generator.last_generation_stats or {}
+        prefill_time = stats.get("prefill_time_s", 0)
+        decode_time = stats.get("decode_time_s", 0)
+        if prefill_time or decode_time:
+            print(f"Prefill: {prefill_time * 1000:.1f} ms | Decode: {decode_time * 1000:.1f} ms")
     else:
         result = tool.benchmark_mode(
             warmup_prompts_per_file=1,

--- a/examples/only_output.py
+++ b/examples/only_output.py
@@ -11,7 +11,14 @@ if __name__ == "__main__":
         type=str,
         help="Path to the SafeTensors checkpoint (default: %(default)s with modelscope)"
     )
+    parser.add_argument(
+        "--cpu-offload",
+        action="store_true",
+        default=None,
+        dest="cpu_offload",
+        help="Enable CPU offload for MoE expert weights",
+    )
     args = parser.parse_args()
     checkpoint = get_model_with_checkpoint(args.checkpoint)
-    tool = HarmonyChatTool(checkpoint, reasoning_effort="high")
+    tool = HarmonyChatTool(checkpoint, reasoning_effort="high", cpu_offload=args.cpu_offload)
     result = tool.only_output()

--- a/tritonllm/gpt_oss/bench.py
+++ b/tritonllm/gpt_oss/bench.py
@@ -62,7 +62,7 @@ class HarmonyChatTool:
                  reasoning_effort: str = "high", developer_message: str = "",
                  enable_browser: bool = False, enable_python: bool = False,
                  enable_apply_patch: bool = False, show_browser_results: bool = False,
-                 raw_mode: bool = False):
+                 raw_mode: bool = False, cpu_offload: bool | None = None):
         self.checkpoint_path = checkpoint_path
         self.context_length = context_length
         self.reasoning_effort = reasoning_effort
@@ -72,6 +72,7 @@ class HarmonyChatTool:
         self.enable_apply_patch = enable_apply_patch
         self.show_browser_results = show_browser_results
         self.raw_mode = raw_mode
+        self.cpu_offload = cpu_offload
 
         # Initialize components
         self.device = torch.device("cuda:0")
@@ -122,16 +123,16 @@ class HarmonyChatTool:
         # Initialize generator with loading message
         try:
             from tritonllm.gpt_oss.triton.model import TokenGenerator as TritonGenerator
-            self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device)
+            self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device, cpu_offload=self.cpu_offload)
         except ImportError:
             try:
                 from gpt_oss.triton.model import TokenGenerator as TritonGenerator
-                self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device)
+                self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device, cpu_offload=self.cpu_offload)
             except ImportError:
                 try:
                     # Try the new import path from the tools code
                     from .triton.model import TokenGenerator as TritonGenerator
-                    self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device)
+                    self.generator = TritonGenerator(self.checkpoint_path, self.context_length, self.device, cpu_offload=self.cpu_offload)
                 except ImportError:
                     raise ImportError("Could not import TokenGenerator. Please check your installation.")
         print(termcolor.colored("✓ Model checkpoint loaded successfully", "green"), flush=True)

--- a/tritonllm/gpt_oss/chat.py
+++ b/tritonllm/gpt_oss/chat.py
@@ -67,7 +67,8 @@ def chat(args):
     tokenizer = get_tokenizer()
     checkpoint = get_model_with_checkpoint(args.checkpoint)
     from .triton.model import TokenGenerator as TritonGenerator
-    generator = TritonGenerator(checkpoint, args.context, device)
+    cpu_offload = getattr(args, 'cpu_offload', None)
+    generator = TritonGenerator(checkpoint, args.context, device, cpu_offload=cpu_offload)
 
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
@@ -388,5 +389,12 @@ def get_parser_args():
         default=False,
         action="store_true",
         help="Raw mode (does not render Harmony encoding)",
+    )
+    parser.add_argument(
+        "--cpu-offload",
+        action="store_true",
+        default=None,
+        dest="cpu_offload",
+        help="Enable CPU offload for MoE expert weights",
     )
     return parser.parse_args()

--- a/tritonllm/gpt_oss/generate.py
+++ b/tritonllm/gpt_oss/generate.py
@@ -14,7 +14,8 @@ def generate(args):
     from gpt_oss.triton.model import TokenGenerator as TritonGenerator
     device = torch.device(f"cuda:0")
     checkpoint = get_model_with_checkpoint(args.checkpoint)
-    generator = TritonGenerator(checkpoint, context=args.context_length, device=device)
+    cpu_offload = getattr(args, 'cpu_offload', None)
+    generator = TritonGenerator(checkpoint, context=args.context_length, device=device, cpu_offload=cpu_offload)
 
     tokenizer = get_tokenizer()
     tokens = tokenizer.encode(args.prompt)
@@ -67,5 +68,12 @@ def get_parser_args():
         type=int,
         default=4096,
         help="Context length",
+    )
+    parser.add_argument(
+        "--cpu-offload",
+        action="store_true",
+        default=None,
+        dest="cpu_offload",
+        help="Enable CPU offload for MoE expert weights",
     )
     return parser.parse_args()

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -50,6 +50,30 @@ class ExpertCache:
         # Track which layer's data is currently in each GPU expert slot (CPU-side)
         self.gpu_layer: list[int] = []  # [layer_idx] * num_experts, -1 = invalid
 
+        # Per-layer CUDA graph: gate routing (captured once, shared across layers)
+        self.route_graph: torch.cuda.CUDAGraph | None = None
+        self._gr_t: torch.Tensor | None = None        # input activation buffer
+        self._gr_wg: torch.Tensor | None = None        # gate weight buffer
+        self._gr_bg: torch.Tensor | None = None        # gate bias buffer
+        self._gr_rdata = None   # RoutingData output (set during capture)
+        self._gr_gather = None  # GatherIndx output
+        self._gr_scatter = None # ScatterIndx output
+
+        # Per-layer CUDA graph for decode matmul (captured once, shared across layers)
+        self.decode_graph: torch.cuda.CUDAGraph | None = None
+        self._g_x: torch.Tensor | None = None       # input activation buffer
+        self._g_out: torch.Tensor | None = None      # output activation (set during capture)
+        self._g_topk: torch.Tensor | None = None     # gather.src_indx / scatter.dst_indx
+        self._g_gate: torch.Tensor | None = None     # gather.dst_indx / scatter.src_indx
+        self._g_scale: torch.Tensor | None = None    # gate_scal
+        self._g_hist: torch.Tensor | None = None     # expt_hist
+        self._g_offs_raw: torch.Tensor | None = None # token_offs_raw
+        self._g_offs_pad: dict[int, torch.Tensor] = {}
+        self._g_pid_map: dict[int, torch.Tensor] = {}
+        self._g_rdata = None   # proxy RoutingData
+        self._g_gather = None  # proxy GatherIndx
+        self._g_scatter = None # proxy ScatterIndx
+
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
@@ -149,8 +173,139 @@ class ExpertCache:
         """Load every expert for *layer_idx* into the GPU buffers (for prefill)."""
         self.ensure_experts(layer_idx, list(range(self.num_experts)))
 
+    # ------------------------------------------------------------------
+    # CUDA Graph (decode matmul)
+    # ------------------------------------------------------------------
+
+    def init_decode_graph(
+        self,
+        rdata,           # RoutingData from triton_kernels.routing
+        gather_indx,     # GatherIndx
+        scatter_indx,    # ScatterIndx
+        swiglu_limit: float = 7.0,
+    ) -> None:
+        """Capture a CUDA graph for the decode-matmul path.
+
+        Called once after the first decode routing step.  The graph
+        captures ``moe_decode_experts`` reading from the shared GPU
+        buffers, so it can be replayed for every layer / every token
+        as long as the buffers are refreshed beforehand.
+        """
+        from triton_kernels.routing import GatherIndx, ScatterIndx, RoutingData, ExptData
+        from .moe import moe_decode_experts
+
+        # Snapshot the routing tensors (these become the fixed-address proxies)
+        self._g_topk = gather_indx.src_indx.clone()
+        self._g_gate = gather_indx.dst_indx.clone()
+        self._g_scale = rdata.gate_scal.clone()
+        self._g_hist = rdata.expt_hist.clone()
+        self._g_offs_raw = rdata.expt_data.token_offs_raw.clone()
+        self._g_offs_pad = {k: v.clone() for k, v in rdata.expt_data.token_offs_pad.items()}
+        self._g_pid_map = {k: v.clone() for k, v in rdata.expt_data.block_pid_map.items()}
+
+        expt_data = ExptData(
+            hist=self._g_hist,
+            token_offs_raw=self._g_offs_raw,
+            token_offs_pad=self._g_offs_pad,
+            block_pid_map=self._g_pid_map,
+        )
+        self._g_rdata = RoutingData(
+            gate_scal=self._g_scale,
+            expt_hist=self._g_hist,
+            n_expts_tot=rdata.n_expts_tot,
+            n_expts_act=rdata.n_expts_act,
+            expt_data=expt_data,
+        )
+        self._g_gather = GatherIndx(src_indx=self._g_topk, dst_indx=self._g_gate)
+        self._g_scatter = ScatterIndx(src_indx=self._g_gate, dst_indx=self._g_topk)
+
+        # Input buffer — same shape as the decode activation
+        hidden_size = self.gpu_b2.shape[1]
+        self._g_x = self.gpu_b2.new_zeros(1, hidden_size, dtype=torch.bfloat16)
+
+        self.decode_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.decode_graph):
+            self._g_out = moe_decode_experts(
+                self._g_x,
+                self.gpu_w1, self.gpu_w1_mx,
+                self.gpu_w2, self.gpu_w2_mx,
+                self.gpu_b1, self.gpu_b2,
+                self._g_rdata, self._g_gather, self._g_scatter,
+                swiglu_limit=swiglu_limit,
+            )
+
+    def update_graph_routing(
+        self,
+        rdata,
+        gather_indx,
+        scatter_indx,
+    ) -> None:
+        """Copy fresh routing results into the graph's proxy tensors."""
+        self._g_topk.copy_(gather_indx.src_indx)
+        self._g_gate.copy_(gather_indx.dst_indx)
+        self._g_scale.copy_(rdata.gate_scal)
+        self._g_hist.copy_(rdata.expt_hist)
+        self._g_offs_raw.copy_(rdata.expt_data.token_offs_raw)
+        for k in self._g_offs_pad:
+            self._g_offs_pad[k].copy_(rdata.expt_data.token_offs_pad[k])
+        for k in self._g_pid_map:
+            self._g_pid_map[k].copy_(rdata.expt_data.block_pid_map[k])
+
+    # ------------------------------------------------------------------
+    # CUDA Graph (decode gate routing)
+    # ------------------------------------------------------------------
+
+    def init_route_graph(
+        self,
+        t: torch.Tensor,
+        wg: torch.Tensor,
+        bg: torch.Tensor | None,
+        experts_per_token: int = 4,
+        num_experts: int = 128,
+    ) -> None:
+        """Capture a CUDA graph for the decode gate-routing path.
+
+        The graph replays ``moe_decode_gate_routing`` writing into
+        fixed-address proxy tensors.  Before each replay the caller
+        must copy the current layer's *t*, *wg*, *bg* into
+        ``_gr_t``, ``_gr_wg``, ``_gr_bg``.
+        """
+        from .moe import moe_decode_gate_routing
+
+        # Pre-allocate input buffers
+        self._gr_t = t.clone()
+        self._gr_wg = wg.clone()
+        self._gr_bg = bg.clone() if bg is not None else None
+
+        self.route_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.route_graph):
+            self._gr_rdata, self._gr_gather, self._gr_scatter = moe_decode_gate_routing(
+                self._gr_t, self._gr_wg, self._gr_bg,
+                experts_per_token=experts_per_token,
+                num_experts=num_experts,
+            )
+
+    def route_to_matmul_proxies(self) -> None:
+        """Copy route-graph outputs into the matmul-graph proxy tensors."""
+        self._g_topk.copy_(self._gr_gather.src_indx)
+        self._g_gate.copy_(self._gr_gather.dst_indx)
+        self._g_scale.copy_(self._gr_rdata.gate_scal)
+        self._g_hist.copy_(self._gr_rdata.expt_hist)
+        self._g_offs_raw.copy_(self._gr_rdata.expt_data.token_offs_raw)
+        for k in self._g_offs_pad:
+            self._g_offs_pad[k].copy_(self._gr_rdata.expt_data.token_offs_pad[k])
+        for k in self._g_pid_map:
+            self._g_pid_map[k].copy_(self._gr_rdata.expt_data.block_pid_map[k])
+
     def free_gpu_buffers(self) -> None:
         """Release all global GPU buffers to reclaim memory."""
+        self.route_graph = None
+        self.decode_graph = None
+        self._gr_t = None
+        self._gr_wg = None
+        self._gr_bg = None
+        self._g_x = None
+        self._g_out = None
         self.gpu_w1 = None
         self.gpu_w1_mx = None
         self.gpu_b1 = None

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -2,13 +2,8 @@
 
 Stores MoE expert weights on CPU (pageable, contiguous per-tensor) and
 maintains shared GPU buffers that are filled on-demand as each layer's
-experts are activated.
-
-Key optimization — GPU hot-layer cache:
-Uses free VRAM to keep the full 128-expert tensor set for N layers
-permanently on GPU.  When a cached layer is hit, its experts are
-copied from the GPU cache to the shared buffers via 6 large GPU→GPU
-copies at ~900 GB/s, avoiding 24 pageable CPU→GPU copies entirely.
+experts are activated.  Only the activated experts (4/128) are transferred
+per layer.
 """
 
 from typing import Optional
@@ -17,11 +12,12 @@ import torch
 
 
 class ExpertCache:
-    """Expert weight cache with hot-layer GPU cache.
+    """Global GPU buffers for expert weights, shared across all layers.
 
-    Shared GPU buffers (128 experts) are reused across all layers.
-    A separate per-layer GPU cache holds the full expert set for
-    frequently-accessed layers, eliminating CPU→GPU transfers.
+    Each layer's expert weights are stored on CPU as contiguous pageable
+    tensors whose layout matches the GPU buffers (``(num_experts, ...)``).
+    Before each MLP forward the activated experts for that layer are copied
+    from CPU into the corresponding GPU slots.
     """
 
     def __init__(
@@ -37,7 +33,7 @@ class ExpertCache:
         # Per-layer pageable CPU storage — contiguous per-tensor
         self.cpu: dict[int, dict[str, torch.Tensor]] = {}
 
-        # Global GPU buffers — shared across all layers (128 experts)
+        # Global GPU buffers — the custom Tensor objects themselves
         self.gpu_w1 = None
         self.gpu_w1_mx = None
         self.gpu_b1: Optional[torch.Tensor] = None
@@ -47,17 +43,6 @@ class ExpertCache:
 
         # Track which layer is in each GPU slot
         self.gpu_layer: list[int] = []
-
-        # ---- Hot-layer GPU cache ----
-        # Per-layer full (128-expert) GPU tensors that persist across tokens.
-        # When a cached layer is requested, 6 big GPU→GPU copies replace
-        # 24 small CPU→GPU copies.
-        self._cache: dict[int, dict[str, torch.Tensor]] = {}
-        self._cache_order: list[int] = []  # LRU: front=MRU, back=LRU
-        self._cache_capacity: int = 0
-        self._cache_bytes_per_layer: int = 0
-        self._cache_hits: int = 0
-        self._cache_misses: int = 0
 
         # ---- CUDA Graph: gate routing ----
         self.route_graph: torch.cuda.CUDAGraph | None = None
@@ -143,24 +128,16 @@ class ExpertCache:
                 yield key, t
 
     # ------------------------------------------------------------------
-    # Public API — shared GPU buffers (CPU→GPU)
+    # Public API
     # ------------------------------------------------------------------
 
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
         """Copy expert weights from CPU → GPU if not already present.
 
-        If *layer_idx* is in the hot-layer GPU cache, copies from the
-        cache (GPU→GPU at ~900 GB/s) instead of from CPU.
+        CPU storage is contiguous per-tensor (shape ``(num_experts, ...)``),
+        so each ``cpu_tensor[eid]`` is a contiguous slice that maps directly
+        to the corresponding GPU slot.
         """
-        # Hot-layer cache hit: copy from GPU cache → shared GPU buffers
-        if layer_idx in self._cache:
-            self._copy_from_cache(layer_idx)
-            self._cache_hits += 1
-            self._touch_cache(layer_idx)
-            return
-
-        # Cache miss: copy from pageable CPU
-        self._cache_misses += 1
         gpu_w1_raw = self._raw_data(self.gpu_w1)
         gpu_w2_raw = self._raw_data(self.gpu_w2)
         gpu_w1_mx_raw = self._raw_data(self.gpu_w1_mx) if self.gpu_w1_mx is not None else None
@@ -198,144 +175,6 @@ class ExpertCache:
     def load_all_experts(self, layer_idx: int) -> None:
         """Load every expert into the shared GPU buffers (for prefill)."""
         self.ensure_experts(layer_idx, list(range(self.num_experts)))
-
-    # ------------------------------------------------------------------
-    # Hot-layer GPU cache
-    # ------------------------------------------------------------------
-
-    def init_layer_cache(self, max_layers: int = 999) -> int:
-        """Determine how many full-layer GPU caches fit in free VRAM.
-
-        Must be called after all ``register_layer`` calls so that tensor
-        sizes are known.  Returns the actual number of cache slots
-        available.  Actual GPU allocation is deferred to ``cache_layer``.
-        """
-        gpu_w1_raw = self._raw_data(self.gpu_w1)
-        gpu_w2_raw = self._raw_data(self.gpu_w2)
-
-        total_bytes = (
-            gpu_w1_raw.numel() * gpu_w1_raw.element_size()
-            + gpu_w2_raw.numel() * gpu_w2_raw.element_size()
-            + self.gpu_b1.numel() * self.gpu_b1.element_size()
-            + self.gpu_b2.numel() * self.gpu_b2.element_size()
-        )
-        if self.gpu_w1_mx is not None:
-            total_bytes += self._raw_data(self.gpu_w1_mx).numel() * self._raw_data(self.gpu_w1_mx).element_size()
-        if self.gpu_w2_mx is not None:
-            total_bytes += self._raw_data(self.gpu_w2_mx).numel() * self._raw_data(self.gpu_w2_mx).element_size()
-
-        self._cache_bytes_per_layer = total_bytes
-
-        free, _ = torch.cuda.mem_get_info(self.device)
-        # Reserve 2 GB for KV cache, activations, CUDA graph workspace.
-        inference_headroom = 2 * 1024**3
-        usable = max(0, int(free) - inference_headroom)
-        self._cache_capacity = min(max_layers, max(0, usable // total_bytes))
-        if self._cache_capacity > 0:
-            print(f"[cache] {self._cache_capacity} layer slots "
-                  f"({self._cache_capacity * total_bytes / 1e9:.2f} GB) "
-                  f"from {usable / 1e9:.2f} GB usable VRAM")
-
-        # Deferred allocation — actual GPU tensors created in cache_layer
-        self._cache_order = [-1] * self._cache_capacity
-
-        return self._cache_capacity
-
-    def cache_layer(self, layer_idx: int) -> bool:
-        """Fill the GPU cache for *layer_idx* from CPU pageable storage.
-
-        Returns True if the layer was cached, False if cache is disabled
-        or the layer is already cached.
-        """
-        if self._cache_capacity == 0:
-            return False
-        if layer_idx in self._cache:
-            self._touch_cache(layer_idx)
-            return True
-
-        # Evict LRU layer if cache is full
-        if len(self._cache) >= self._cache_capacity:
-            evict_idx = self._cache_order[-1]
-            if evict_idx >= 0 and evict_idx in self._cache:
-                del self._cache[evict_idx]
-                self._cache_order[-1] = -1
-
-        # Find a free slot
-        slot = -1
-        for i, lid in enumerate(self._cache_order):
-            if lid < 0 or lid not in self._cache:
-                slot = i
-                break
-        if slot < 0:
-            slot = len(self._cache_order) - 1  # reuse last slot
-
-        # Allocate buffers in this slot if first use
-        if self._cache_order[slot] < 0:
-            # Already allocated in init_layer_cache; just assign
-            self._cache_order[slot] = layer_idx
-            self._cache[layer_idx] = {}  # filled below
-
-        # Copy all 128 experts from pageable CPU to GPU cache
-        cpu_layer = self.cpu[layer_idx]
-        cache_entry = self._cache.setdefault(layer_idx, {})
-        for key in ["w1", "w1_mx", "b1", "w2", "w2_mx", "b2"]:
-            if key in cpu_layer:
-                if key not in cache_entry:
-                    # Allocate on first use
-                    cache_entry[key] = cpu_layer[key].to(self.device)
-                else:
-                    cache_entry[key].copy_(cpu_layer[key])
-
-        self._touch_cache(layer_idx)
-        return True
-
-    def cache_stats(self) -> dict:
-        """Return cache hit/miss counters."""
-        total = self._cache_hits + self._cache_misses
-        return {
-            "hits": self._cache_hits,
-            "misses": self._cache_misses,
-            "hit_rate": self._cache_hits / total if total > 0 else 0.0,
-            "capacity": self._cache_capacity,
-            "active": len(self._cache),
-            "bytes_per_layer_mb": self._cache_bytes_per_layer / (1024 * 1024),
-        }
-
-    def _copy_from_cache(self, layer_idx: int) -> None:
-        """Copy all 128 experts from GPU cache → shared GPU buffers.
-
-        Six large contiguous GPU→GPU copies at ~900 GB/s, replacing
-        24 small pageable CPU→GPU copies at ~15 GB/s.
-        """
-        cache_entry = self._cache[layer_idx]
-        gpu_w1_raw = self._raw_data(self.gpu_w1)
-        gpu_w2_raw = self._raw_data(self.gpu_w2)
-
-        gpu_w1_raw.copy_(cache_entry["w1"])
-        if self.gpu_w1_mx is not None and "w1_mx" in cache_entry:
-            self._raw_data(self.gpu_w1_mx).copy_(cache_entry["w1_mx"])
-        self.gpu_b1.copy_(cache_entry["b1"])
-        gpu_w2_raw.copy_(cache_entry["w2"])
-        if self.gpu_w2_mx is not None and "w2_mx" in cache_entry:
-            self._raw_data(self.gpu_w2_mx).copy_(cache_entry["w2_mx"])
-        self.gpu_b2.copy_(cache_entry["b2"])
-
-        # Mark all 128 GPU slots as belonging to this layer
-        for eid in range(self.num_experts):
-            self.gpu_layer[eid] = layer_idx
-
-    def _touch_cache(self, layer_idx: int) -> None:
-        """Move *layer_idx* to the front of the LRU order."""
-        if layer_idx in self._cache_order:
-            self._cache_order.remove(layer_idx)
-        while len(self._cache_order) < self._cache_capacity:
-            self._cache_order.append(-1)
-        self._cache_order.insert(0, layer_idx)
-        # Trim to capacity
-        while len(self._cache_order) > self._cache_capacity:
-            removed = self._cache_order.pop()
-            if removed >= 0 and removed in self._cache:
-                del self._cache[removed]
 
     # ------------------------------------------------------------------
     # CUDA Graph (decode matmul)
@@ -444,6 +283,4 @@ class ExpertCache:
         self.gpu_w2 = None
         self.gpu_w2_mx = None
         self.gpu_b2 = None
-        self._cache.clear()
-        self._cache_order.clear()
         self.gpu_layer = []

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -13,7 +13,47 @@ dimension, so ``storage.data[eid]`` correctly isolates a single expert.
 
 from typing import Optional
 
+import ctypes
 import torch
+
+
+# ------------------------------------------------------------------
+# In-place CPU memory pinning via cudaHostRegister / cudaHostUnregister.
+# Temporarily pins source tensors so that ``copy_`` to GPU uses DMA,
+# then unpins immediately after.  Only 4 experts are pinned at a time.
+# ------------------------------------------------------------------
+
+_PAGE_SIZE = 4096
+
+
+def _pin_cpu(tensor: torch.Tensor) -> bool:
+    """Pin *tensor*'s memory in-place via cudaHostRegister. Returns True on success."""
+    ptr = tensor.data_ptr()
+    size = tensor.numel() * tensor.element_size()
+    aligned_ptr = ptr & ~(_PAGE_SIZE - 1)
+    offset = ptr - aligned_ptr
+    aligned_size = size + offset
+    try:
+        cuda = torch.cuda.cudart()
+        cuda.cudaHostRegister.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint]
+        cuda.cudaHostRegister.restype = ctypes.c_int
+        err = cuda.cudaHostRegister(ctypes.c_void_p(aligned_ptr), aligned_size, 0)
+        return err == 0
+    except Exception:
+        return False
+
+
+def _unpin_cpu(tensor: torch.Tensor) -> None:
+    """Unpin memory previously pinned with _pin_cpu."""
+    ptr = tensor.data_ptr()
+    aligned_ptr = ptr & ~(_PAGE_SIZE - 1)
+    try:
+        cuda = torch.cuda.cudart()
+        cuda.cudaHostUnregister.argtypes = [ctypes.c_void_p]
+        cuda.cudaHostUnregister.restype = ctypes.c_int
+        cuda.cudaHostUnregister(ctypes.c_void_p(aligned_ptr))
+    except Exception:
+        pass
 
 
 class ExpertCache:
@@ -139,7 +179,12 @@ class ExpertCache:
     # ------------------------------------------------------------------
 
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
-        """Synchronously copy expert weights from CPU → GPU if not already present."""
+        """Synchronously copy expert weights from CPU → GPU if not already present.
+
+        Temporarily pins source CPU memory via cudaHostRegister so the
+        copy uses DMA, then unpins immediately to limit pinned-memory
+        pressure to only the active experts.
+        """
         gpu_w1_raw = self.gpu_w1.storage.data
         gpu_w2_raw = self.gpu_w2.storage.data
         gpu_w1_mx_raw = (
@@ -159,14 +204,34 @@ class ExpertCache:
             if self.gpu_layer[eid_i] == layer_idx:
                 continue
             cw = cpu_layer[eid_i]
+
+            # Pin source, copy, unpin — per tensor to keep pinned footprint tiny
+            _pin_cpu(cw["w1"])
             gpu_w1_raw[eid_i].copy_(cw["w1"])
+            _unpin_cpu(cw["w1"])
+
             if gpu_w1_mx_raw is not None and cw["w1_mx"] is not None:
+                _pin_cpu(cw["w1_mx"])
                 gpu_w1_mx_raw[eid_i].copy_(cw["w1_mx"])
+                _unpin_cpu(cw["w1_mx"])
+
+            _pin_cpu(cw["b1"])
             self.gpu_b1[eid_i].copy_(cw["b1"])
+            _unpin_cpu(cw["b1"])
+
+            _pin_cpu(cw["w2"])
             gpu_w2_raw[eid_i].copy_(cw["w2"])
+            _unpin_cpu(cw["w2"])
+
             if gpu_w2_mx_raw is not None and cw["w2_mx"] is not None:
+                _pin_cpu(cw["w2_mx"])
                 gpu_w2_mx_raw[eid_i].copy_(cw["w2_mx"])
+                _unpin_cpu(cw["w2_mx"])
+
+            _pin_cpu(cw["b2"])
             self.gpu_b2[eid_i].copy_(cw["b2"])
+            _unpin_cpu(cw["b2"])
+
             self.gpu_layer[eid_i] = layer_idx
 
     def load_all_experts(self, layer_idx: int) -> None:

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -50,6 +50,11 @@ class ExpertCache:
         # Track which layer's data is currently in each GPU expert slot (CPU-side)
         self.gpu_layer: list[int] = []  # [layer_idx] * num_experts, -1 = invalid
 
+        # GPU hot-layer cache: permanent GPU storage for selected layers
+        # gpu_cache[layer_idx] = {"w1": raw_tensor, "w2": ..., "b1": ..., "b2": ...}
+        self.gpu_cache: dict[int, dict[str, torch.Tensor]] = {}
+        self._cache_bytes_per_layer: int = 0
+
         # Per-layer CUDA graph: gate routing (captured once, shared across layers)
         self.route_graph: torch.cuda.CUDAGraph | None = None
         self._gr_t: torch.Tensor | None = None        # input activation buffer
@@ -87,10 +92,12 @@ class ExpertCache:
         w2,           # custom Tensor, shape (E, ...)
         w2_mx,        # MXFP4 scales
         b2: torch.Tensor,   # (E, hidden_size) bf16
+        cache_on_gpu: bool = False,
     ) -> None:
         """Store per-expert CPU copies and initialise global GPU buffers.
 
         Called once per MLP layer after weight loading + quantization.
+        When ``cache_on_gpu=True``, weights stay on GPU for fast D2D access.
         """
         # Allocate global GPU buffers on first call (keep first layer's tensors)
         if self.gpu_w1 is None:
@@ -106,20 +113,67 @@ class ExpertCache:
             )
             self.gpu_layer = [-1] * self.num_experts
 
-        # Slice by expert and move to CPU (via .storage.data for custom Tensors)
-        cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
-        for eid in range(self.num_experts):
-            cpu_layer[eid] = {
-                "w1": self._raw_slice_cpu(w1, eid),
-                "w1_mx": self._raw_slice_cpu(w1_mx, eid)
-                if w1_mx is not None else None,
-                "b1": b1[eid].cpu(),
-                "w2": self._raw_slice_cpu(w2, eid),
-                "w2_mx": self._raw_slice_cpu(w2_mx, eid)
-                if w2_mx is not None else None,
-                "b2": b2[eid].cpu(),
+            # Measure per-layer bytes for cache capacity planning
+            w1_raw = self._raw_data(w1)
+            w2_raw = self._raw_data(w2)
+            b1_f32 = b1.to(torch.float32)
+            b2_f32 = b2.to(torch.float32)
+            w1_mx_raw = self._raw_data(w1_mx) if w1_mx is not None else None
+            w2_mx_raw = self._raw_data(w2_mx) if w2_mx is not None else None
+            self._cache_bytes_per_layer = (
+                w1_raw.numel() * w1_raw.element_size() +
+                w2_raw.numel() * w2_raw.element_size() +
+                b1_f32.numel() * 4 +
+                b2_f32.numel() * 4 +
+                (w1_mx_raw.numel() * w1_mx_raw.element_size() if w1_mx_raw is not None else 0) +
+                (w2_mx_raw.numel() * w2_mx_raw.element_size() if w2_mx_raw is not None else 0)
+            )
+
+        if cache_on_gpu:
+            # Keep raw tensors on GPU for fast D2D copies
+            self.gpu_cache[layer_idx] = {
+                "w1": self._raw_data(w1),
+                "w1_mx": self._raw_data(w1_mx) if w1_mx is not None else None,
+                "b1": b1.to(torch.float32),
+                "w2": self._raw_data(w2),
+                "w2_mx": self._raw_data(w2_mx) if w2_mx is not None else None,
+                "b2": b2.to(torch.float32),
             }
-        self.cpu[layer_idx] = cpu_layer
+            # Also store CPU copies for the non-cache path if needed
+            cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
+            for eid in range(self.num_experts):
+                cpu_layer[eid] = {
+                    "w1": self._raw_slice_cpu(w1, eid),
+                    "w1_mx": self._raw_slice_cpu(w1_mx, eid)
+                    if w1_mx is not None else None,
+                    "b1": b1[eid].cpu(),
+                    "w2": self._raw_slice_cpu(w2, eid),
+                    "w2_mx": self._raw_slice_cpu(w2_mx, eid)
+                    if w2_mx is not None else None,
+                    "b2": b2[eid].cpu(),
+                }
+            self.cpu[layer_idx] = cpu_layer
+        else:
+            cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
+            for eid in range(self.num_experts):
+                cpu_layer[eid] = {
+                    "w1": self._raw_slice_cpu(w1, eid),
+                    "w1_mx": self._raw_slice_cpu(w1_mx, eid)
+                    if w1_mx is not None else None,
+                    "b1": b1[eid].cpu(),
+                    "w2": self._raw_slice_cpu(w2, eid),
+                    "w2_mx": self._raw_slice_cpu(w2_mx, eid)
+                    if w2_mx is not None else None,
+                    "b2": b2[eid].cpu(),
+                }
+            self.cpu[layer_idx] = cpu_layer
+
+    @staticmethod
+    def _raw_data(tensor) -> torch.Tensor:
+        """Return the underlying torch.Tensor for a regular or custom Tensor."""
+        if hasattr(tensor, "storage") and hasattr(tensor.storage, "data"):
+            return tensor.storage.data
+        return tensor
 
     @staticmethod
     def _raw_slice_cpu(tensor, index: int) -> torch.Tensor:
@@ -138,8 +192,38 @@ class ExpertCache:
     # Public API
     # ------------------------------------------------------------------
 
+    def init_layer_cache(self, max_layers: int = 0) -> int:
+        """Determine how many hot layers can be cached in free GPU memory.
+
+        Returns the number of layers that can be cached (0 if insufficient VRAM).
+        The caller should then call ``cache_on_gpu=True`` during
+        ``register_layer`` for the first *n* layers.
+        """
+        if self._cache_bytes_per_layer == 0 or max_layers <= 0:
+            return 0
+        free, total = torch.cuda.mem_get_info()
+        used = total - free
+        # Reserve 2 GB for inference overhead (activations, CUDA graphs, etc.)
+        usable = max(0, free - 2 * 1024**3)
+        n = min(max_layers, int(usable // self._cache_bytes_per_layer))
+        if n > 0:
+            print(f"GPU layer cache: {n} slots "
+                  f"({self._cache_bytes_per_layer * n / 1e9:.2f} GB of "
+                  f"{free / 1e9:.2f} GB free VRAM)")
+        else:
+            print(f"GPU layer cache: insufficient free VRAM "
+                  f"(need {self._cache_bytes_per_layer / 1e9:.2f} GB/layer, "
+                  f"{free / 1e9:.2f} GB free)")
+        return n
+
+    def is_cached(self, layer_idx: int) -> bool:
+        return layer_idx in self.gpu_cache
+
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
-        """Synchronously copy expert weights from CPU → GPU if not already present."""
+        """Copy expert weights to GPU shared buffers if not already present.
+
+        Uses GPU→GPU D2D copy for hot-cached layers, CPU→GPU copy otherwise.
+        """
         gpu_w1_raw = self.gpu_w1.storage.data
         gpu_w2_raw = self.gpu_w2.storage.data
         gpu_w1_mx_raw = (
@@ -152,8 +236,33 @@ class ExpertCache:
             if self.gpu_w2_mx is not None and hasattr(self.gpu_w2_mx, "storage")
             else self.gpu_w2_mx
         )
-        cpu_layer = self.cpu[layer_idx]
 
+        cached = self.gpu_cache.get(layer_idx)
+        if cached is not None:
+            # Hot-layer path: D2D copy from permanent GPU cache
+            cw1 = cached["w1"]
+            cw1_mx = cached["w1_mx"]
+            cb1 = cached["b1"]
+            cw2 = cached["w2"]
+            cw2_mx = cached["w2_mx"]
+            cb2 = cached["b2"]
+            for eid in expert_ids:
+                eid_i = int(eid)
+                if self.gpu_layer[eid_i] == layer_idx:
+                    continue
+                gpu_w1_raw[eid_i].copy_(cw1[eid_i])
+                if gpu_w1_mx_raw is not None and cw1_mx is not None:
+                    gpu_w1_mx_raw[eid_i].copy_(cw1_mx[eid_i])
+                self.gpu_b1[eid_i].copy_(cb1[eid_i])
+                gpu_w2_raw[eid_i].copy_(cw2[eid_i])
+                if gpu_w2_mx_raw is not None and cw2_mx is not None:
+                    gpu_w2_mx_raw[eid_i].copy_(cw2_mx[eid_i])
+                self.gpu_b2[eid_i].copy_(cb2[eid_i])
+                self.gpu_layer[eid_i] = layer_idx
+            return
+
+        # Cold-layer path: CPU→GPU copy from pageable CPU storage
+        cpu_layer = self.cpu[layer_idx]
         for eid in expert_ids:
             eid_i = int(eid)
             if self.gpu_layer[eid_i] == layer_idx:

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -1,0 +1,160 @@
+"""CPU/GPU hybrid expert weight cache for MoE models.
+
+Stores MoE expert weights on CPU and maintains a shared set of GPU buffers
+that are filled on-demand as each layer's experts are activated. The routing
+step tells us exactly which experts are needed before the heavy matmul, so
+we only transfer the activated experts (4/128) per layer.
+
+The custom Tensor types from ``quantize_mx4`` do not expose ``cpu()`` or
+``clone()`` directly, so we work with the underlying ``torch.Tensor`` via
+``.storage.data``.  The swizzled layouts preserve the leading (expert)
+dimension, so ``storage.data[eid]`` correctly isolates a single expert.
+"""
+
+from typing import Optional
+
+import torch
+
+
+class ExpertCache:
+    """Global GPU buffers for expert weights, shared across all layers.
+
+    Each layer's expert weights are stored on CPU (per-expert slices of the
+    raw storage).  A single set of ``(num_experts, ...)`` shaped GPU buffers
+    is shared across layers — before each MLP forward the activated experts
+    for that layer are copied from CPU into the corresponding GPU slots.
+    """
+
+    def __init__(
+        self,
+        num_experts: int,
+        experts_per_token: int,
+        device: torch.device,
+    ):
+        self.num_experts = num_experts
+        self.experts_per_token = experts_per_token
+        self.device = device
+
+        # Per-layer, per-expert CPU storage (raw torch.Tensor slices)
+        # cpu[layer_idx][expert_id] = {"w1": Tensor, "w1_mx": Tensor, ...}
+        self.cpu: dict[int, dict[int, dict[str, torch.Tensor]]] = {}
+
+        # Global GPU buffers — the custom Tensor objects themselves
+        self.gpu_w1 = None           # custom Tensor from quantize_mx4
+        self.gpu_w1_mx = None        # custom Tensor (or None)
+        self.gpu_b1: Optional[torch.Tensor] = None  # fp32 (E, intermed*2)
+        self.gpu_w2 = None           # custom Tensor
+        self.gpu_w2_mx = None        # custom Tensor (or None)
+        self.gpu_b2: Optional[torch.Tensor] = None  # fp32 (E, hidden)
+
+        # Track which layer's data is currently in each GPU expert slot (CPU-side)
+        self.gpu_layer: list[int] = []  # [layer_idx] * num_experts, -1 = invalid
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register_layer(
+        self,
+        layer_idx: int,
+        w1,           # custom Tensor from quantize_mx4, shape (E, ...)
+        w1_mx,        # MXFP4 scales, shape (E, ...) — custom Tensor or None
+        b1: torch.Tensor,   # (E, intermediate_size*2) bf16
+        w2,           # custom Tensor, shape (E, ...)
+        w2_mx,        # MXFP4 scales
+        b2: torch.Tensor,   # (E, hidden_size) bf16
+    ) -> None:
+        """Store per-expert CPU copies and initialise global GPU buffers.
+
+        Called once per MLP layer after weight loading + quantization.
+        """
+        # Allocate global GPU buffers on first call (keep first layer's tensors)
+        if self.gpu_w1 is None:
+            self.gpu_w1 = w1
+            self.gpu_w1_mx = w1_mx if w1_mx is not None else None
+            self.gpu_b1 = torch.empty_like(
+                b1, dtype=torch.float32, device=self.device,
+            )
+            self.gpu_w2 = w2
+            self.gpu_w2_mx = w2_mx if w2_mx is not None else None
+            self.gpu_b2 = torch.empty_like(
+                b2, dtype=torch.float32, device=self.device,
+            )
+            self.gpu_layer = [-1] * self.num_experts
+
+        # Slice by expert and move to CPU (via .storage.data for custom Tensors)
+        cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
+        for eid in range(self.num_experts):
+            cpu_layer[eid] = {
+                "w1": self._raw_slice_cpu(w1, eid),
+                "w1_mx": self._raw_slice_cpu(w1_mx, eid)
+                if w1_mx is not None else None,
+                "b1": b1[eid].cpu(),
+                "w2": self._raw_slice_cpu(w2, eid),
+                "w2_mx": self._raw_slice_cpu(w2_mx, eid)
+                if w2_mx is not None else None,
+                "b2": b2[eid].cpu(),
+            }
+        self.cpu[layer_idx] = cpu_layer
+
+    @staticmethod
+    def _raw_slice_cpu(tensor, index: int) -> torch.Tensor:
+        """Slice *tensor* at *index* and move the slice to CPU.
+
+        Works with both regular ``torch.Tensor`` and the custom ``Tensor``
+        from ``triton_kernels.tensor`` (by accessing ``.storage.data``).
+        """
+        if hasattr(tensor, "storage") and hasattr(tensor.storage, "data"):
+            raw = tensor.storage.data  # underlying torch.Tensor
+        else:
+            raw = tensor
+        return raw[index].cpu()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
+        """Synchronously copy expert weights from CPU → GPU if not already present."""
+        gpu_w1_raw = self.gpu_w1.storage.data
+        gpu_w2_raw = self.gpu_w2.storage.data
+        gpu_w1_mx_raw = (
+            self.gpu_w1_mx.storage.data
+            if self.gpu_w1_mx is not None and hasattr(self.gpu_w1_mx, "storage")
+            else self.gpu_w1_mx
+        )
+        gpu_w2_mx_raw = (
+            self.gpu_w2_mx.storage.data
+            if self.gpu_w2_mx is not None and hasattr(self.gpu_w2_mx, "storage")
+            else self.gpu_w2_mx
+        )
+        cpu_layer = self.cpu[layer_idx]
+
+        for eid in expert_ids:
+            eid_i = int(eid)
+            if self.gpu_layer[eid_i] == layer_idx:
+                continue
+            cw = cpu_layer[eid_i]
+            gpu_w1_raw[eid_i].copy_(cw["w1"])
+            if gpu_w1_mx_raw is not None and cw["w1_mx"] is not None:
+                gpu_w1_mx_raw[eid_i].copy_(cw["w1_mx"])
+            self.gpu_b1[eid_i].copy_(cw["b1"])
+            gpu_w2_raw[eid_i].copy_(cw["w2"])
+            if gpu_w2_mx_raw is not None and cw["w2_mx"] is not None:
+                gpu_w2_mx_raw[eid_i].copy_(cw["w2_mx"])
+            self.gpu_b2[eid_i].copy_(cw["b2"])
+            self.gpu_layer[eid_i] = layer_idx
+
+    def load_all_experts(self, layer_idx: int) -> None:
+        """Load every expert for *layer_idx* into the GPU buffers (for prefill)."""
+        self.ensure_experts(layer_idx, list(range(self.num_experts)))
+
+    def free_gpu_buffers(self) -> None:
+        """Release all global GPU buffers to reclaim memory."""
+        self.gpu_w1 = None
+        self.gpu_w1_mx = None
+        self.gpu_b1 = None
+        self.gpu_w2 = None
+        self.gpu_w2_mx = None
+        self.gpu_b2 = None
+        self.gpu_layer = []

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -1,68 +1,27 @@
 """CPU/GPU hybrid expert weight cache for MoE models.
 
-Stores MoE expert weights on CPU and maintains a shared set of GPU buffers
-that are filled on-demand as each layer's experts are activated. The routing
-step tells us exactly which experts are needed before the heavy matmul, so
-we only transfer the activated experts (4/128) per layer.
+Stores MoE expert weights on CPU (pageable, contiguous per-tensor) and
+maintains shared GPU buffers that are filled on-demand as each layer's
+experts are activated.
 
-The custom Tensor types from ``quantize_mx4`` do not expose ``cpu()`` or
-``clone()`` directly, so we work with the underlying ``torch.Tensor`` via
-``.storage.data``.  The swizzled layouts preserve the leading (expert)
-dimension, so ``storage.data[eid]`` correctly isolates a single expert.
+Key optimization — GPU hot-layer cache:
+Uses free VRAM to keep the full 128-expert tensor set for N layers
+permanently on GPU.  When a cached layer is hit, its experts are
+copied from the GPU cache to the shared buffers via 6 large GPU→GPU
+copies at ~900 GB/s, avoiding 24 pageable CPU→GPU copies entirely.
 """
 
 from typing import Optional
 
-import ctypes
 import torch
 
 
-# ------------------------------------------------------------------
-# In-place CPU memory pinning via cudaHostRegister / cudaHostUnregister.
-# Temporarily pins source tensors so that ``copy_`` to GPU uses DMA,
-# then unpins immediately after.  Only 4 experts are pinned at a time.
-# ------------------------------------------------------------------
-
-_PAGE_SIZE = 4096
-
-
-def _pin_cpu(tensor: torch.Tensor) -> bool:
-    """Pin *tensor*'s memory in-place via cudaHostRegister. Returns True on success."""
-    ptr = tensor.data_ptr()
-    size = tensor.numel() * tensor.element_size()
-    aligned_ptr = ptr & ~(_PAGE_SIZE - 1)
-    offset = ptr - aligned_ptr
-    aligned_size = size + offset
-    try:
-        cuda = torch.cuda.cudart()
-        cuda.cudaHostRegister.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint]
-        cuda.cudaHostRegister.restype = ctypes.c_int
-        err = cuda.cudaHostRegister(ctypes.c_void_p(aligned_ptr), aligned_size, 0)
-        return err == 0
-    except Exception:
-        return False
-
-
-def _unpin_cpu(tensor: torch.Tensor) -> None:
-    """Unpin memory previously pinned with _pin_cpu."""
-    ptr = tensor.data_ptr()
-    aligned_ptr = ptr & ~(_PAGE_SIZE - 1)
-    try:
-        cuda = torch.cuda.cudart()
-        cuda.cudaHostUnregister.argtypes = [ctypes.c_void_p]
-        cuda.cudaHostUnregister.restype = ctypes.c_int
-        cuda.cudaHostUnregister(ctypes.c_void_p(aligned_ptr))
-    except Exception:
-        pass
-
-
 class ExpertCache:
-    """Global GPU buffers for expert weights, shared across all layers.
+    """Expert weight cache with hot-layer GPU cache.
 
-    Each layer's expert weights are stored on CPU (per-expert slices of the
-    raw storage).  A single set of ``(num_experts, ...)`` shaped GPU buffers
-    is shared across layers — before each MLP forward the activated experts
-    for that layer are copied from CPU into the corresponding GPU slots.
+    Shared GPU buffers (128 experts) are reused across all layers.
+    A separate per-layer GPU cache holds the full expert set for
+    frequently-accessed layers, eliminating CPU→GPU transfers.
     """
 
     def __init__(
@@ -75,44 +34,54 @@ class ExpertCache:
         self.experts_per_token = experts_per_token
         self.device = device
 
-        # Per-layer, per-expert CPU storage (raw torch.Tensor slices)
-        # cpu[layer_idx][expert_id] = {"w1": Tensor, "w1_mx": Tensor, ...}
-        self.cpu: dict[int, dict[int, dict[str, torch.Tensor]]] = {}
+        # Per-layer pageable CPU storage — contiguous per-tensor
+        self.cpu: dict[int, dict[str, torch.Tensor]] = {}
 
-        # Global GPU buffers — the custom Tensor objects themselves
-        self.gpu_w1 = None           # custom Tensor from quantize_mx4
-        self.gpu_w1_mx = None        # custom Tensor (or None)
-        self.gpu_b1: Optional[torch.Tensor] = None  # fp32 (E, intermed*2)
-        self.gpu_w2 = None           # custom Tensor
-        self.gpu_w2_mx = None        # custom Tensor (or None)
-        self.gpu_b2: Optional[torch.Tensor] = None  # fp32 (E, hidden)
+        # Global GPU buffers — shared across all layers (128 experts)
+        self.gpu_w1 = None
+        self.gpu_w1_mx = None
+        self.gpu_b1: Optional[torch.Tensor] = None
+        self.gpu_w2 = None
+        self.gpu_w2_mx = None
+        self.gpu_b2: Optional[torch.Tensor] = None
 
-        # Track which layer's data is currently in each GPU expert slot (CPU-side)
-        self.gpu_layer: list[int] = []  # [layer_idx] * num_experts, -1 = invalid
+        # Track which layer is in each GPU slot
+        self.gpu_layer: list[int] = []
 
-        # Per-layer CUDA graph: gate routing (captured once, shared across layers)
+        # ---- Hot-layer GPU cache ----
+        # Per-layer full (128-expert) GPU tensors that persist across tokens.
+        # When a cached layer is requested, 6 big GPU→GPU copies replace
+        # 24 small CPU→GPU copies.
+        self._cache: dict[int, dict[str, torch.Tensor]] = {}
+        self._cache_order: list[int] = []  # LRU: front=MRU, back=LRU
+        self._cache_capacity: int = 0
+        self._cache_bytes_per_layer: int = 0
+        self._cache_hits: int = 0
+        self._cache_misses: int = 0
+
+        # ---- CUDA Graph: gate routing ----
         self.route_graph: torch.cuda.CUDAGraph | None = None
-        self._gr_t: torch.Tensor | None = None        # input activation buffer
-        self._gr_wg: torch.Tensor | None = None        # gate weight buffer
-        self._gr_bg: torch.Tensor | None = None        # gate bias buffer
-        self._gr_rdata = None   # RoutingData output (set during capture)
-        self._gr_gather = None  # GatherIndx output
-        self._gr_scatter = None # ScatterIndx output
+        self._gr_t: torch.Tensor | None = None
+        self._gr_wg: torch.Tensor | None = None
+        self._gr_bg: torch.Tensor | None = None
+        self._gr_rdata = None
+        self._gr_gather = None
+        self._gr_scatter = None
 
-        # Per-layer CUDA graph for decode matmul (captured once, shared across layers)
+        # ---- CUDA Graph: decode matmul ----
         self.decode_graph: torch.cuda.CUDAGraph | None = None
-        self._g_x: torch.Tensor | None = None       # input activation buffer
-        self._g_out: torch.Tensor | None = None      # output activation (set during capture)
-        self._g_topk: torch.Tensor | None = None     # gather.src_indx / scatter.dst_indx
-        self._g_gate: torch.Tensor | None = None     # gather.dst_indx / scatter.src_indx
-        self._g_scale: torch.Tensor | None = None    # gate_scal
-        self._g_hist: torch.Tensor | None = None     # expt_hist
-        self._g_offs_raw: torch.Tensor | None = None # token_offs_raw
+        self._g_x: torch.Tensor | None = None
+        self._g_out: torch.Tensor | None = None
+        self._g_topk: torch.Tensor | None = None
+        self._g_gate: torch.Tensor | None = None
+        self._g_scale: torch.Tensor | None = None
+        self._g_hist: torch.Tensor | None = None
+        self._g_offs_raw: torch.Tensor | None = None
         self._g_offs_pad: dict[int, torch.Tensor] = {}
         self._g_pid_map: dict[int, torch.Tensor] = {}
-        self._g_rdata = None   # proxy RoutingData
-        self._g_gather = None  # proxy GatherIndx
-        self._g_scatter = None # proxy ScatterIndx
+        self._g_rdata = None
+        self._g_gather = None
+        self._g_scatter = None
 
     # ------------------------------------------------------------------
     # Registration
@@ -121,18 +90,17 @@ class ExpertCache:
     def register_layer(
         self,
         layer_idx: int,
-        w1,           # custom Tensor from quantize_mx4, shape (E, ...)
-        w1_mx,        # MXFP4 scales, shape (E, ...) — custom Tensor or None
-        b1: torch.Tensor,   # (E, intermediate_size*2) bf16
-        w2,           # custom Tensor, shape (E, ...)
-        w2_mx,        # MXFP4 scales
-        b2: torch.Tensor,   # (E, hidden_size) bf16
+        w1,
+        w1_mx,
+        b1: torch.Tensor,
+        w2,
+        w2_mx,
+        b2: torch.Tensor,
     ) -> None:
-        """Store per-expert CPU copies and initialise global GPU buffers.
+        """Store pageable CPU copies and initialise shared GPU buffers.
 
         Called once per MLP layer after weight loading + quantization.
         """
-        # Allocate global GPU buffers on first call (keep first layer's tensors)
         if self.gpu_w1 is None:
             self.gpu_w1 = w1
             self.gpu_w1_mx = w1_mx if w1_mx is not None else None
@@ -146,97 +114,228 @@ class ExpertCache:
             )
             self.gpu_layer = [-1] * self.num_experts
 
-        # Slice by expert and move to CPU (via .storage.data for custom Tensors)
-        cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
-        for eid in range(self.num_experts):
-            cpu_layer[eid] = {
-                "w1": self._raw_slice_cpu(w1, eid),
-                "w1_mx": self._raw_slice_cpu(w1_mx, eid)
-                if w1_mx is not None else None,
-                "b1": b1[eid].cpu(),
-                "w2": self._raw_slice_cpu(w2, eid),
-                "w2_mx": self._raw_slice_cpu(w2_mx, eid)
-                if w2_mx is not None else None,
-                "b2": b2[eid].cpu(),
-            }
+        # Store pageable CPU tensors — one contiguous tensor per component,
+        # shape (num_experts, ...), matching the GPU buffer layout.
+        cpu_layer: dict[str, torch.Tensor] = {}
+        for key, gpu_tensor in self._iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
+            cpu_layer[key] = self._gpu_to_pageable_cpu(gpu_tensor)
         self.cpu[layer_idx] = cpu_layer
 
-    @staticmethod
-    def _raw_slice_cpu(tensor, index: int) -> torch.Tensor:
-        """Slice *tensor* at *index* and move the slice to CPU.
+    def _gpu_to_pageable_cpu(self, gpu_tensor) -> torch.Tensor:
+        """Copy the entire GPU tensor into a contiguous pageable CPU tensor."""
+        raw = self._raw_data(gpu_tensor)
+        return raw.cpu()
 
-        Works with both regular ``torch.Tensor`` and the custom ``Tensor``
-        from ``triton_kernels.tensor`` (by accessing ``.storage.data``).
-        """
+    @staticmethod
+    def _raw_data(tensor) -> torch.Tensor:
+        """Return the underlying torch.Tensor for a regular or custom Tensor."""
         if hasattr(tensor, "storage") and hasattr(tensor.storage, "data"):
-            raw = tensor.storage.data  # underlying torch.Tensor
-        else:
-            raw = tensor
-        return raw[index].cpu()
+            return tensor.storage.data
+        return tensor
+
+    @staticmethod
+    def _iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
+        for key, t in [
+            ("w1", w1), ("w1_mx", w1_mx), ("b1", b1),
+            ("w2", w2), ("w2_mx", w2_mx), ("b2", b2),
+        ]:
+            if t is not None:
+                yield key, t
 
     # ------------------------------------------------------------------
-    # Public API
+    # Public API — shared GPU buffers (CPU→GPU)
     # ------------------------------------------------------------------
 
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
-        """Synchronously copy expert weights from CPU → GPU if not already present.
+        """Copy expert weights from CPU → GPU if not already present.
 
-        Temporarily pins source CPU memory via cudaHostRegister so the
-        copy uses DMA, then unpins immediately to limit pinned-memory
-        pressure to only the active experts.
+        If *layer_idx* is in the hot-layer GPU cache, copies from the
+        cache (GPU→GPU at ~900 GB/s) instead of from CPU.
         """
-        gpu_w1_raw = self.gpu_w1.storage.data
-        gpu_w2_raw = self.gpu_w2.storage.data
-        gpu_w1_mx_raw = (
-            self.gpu_w1_mx.storage.data
-            if self.gpu_w1_mx is not None and hasattr(self.gpu_w1_mx, "storage")
-            else self.gpu_w1_mx
-        )
-        gpu_w2_mx_raw = (
-            self.gpu_w2_mx.storage.data
-            if self.gpu_w2_mx is not None and hasattr(self.gpu_w2_mx, "storage")
-            else self.gpu_w2_mx
-        )
+        # Hot-layer cache hit: copy from GPU cache → shared GPU buffers
+        if layer_idx in self._cache:
+            self._copy_from_cache(layer_idx)
+            self._cache_hits += 1
+            self._touch_cache(layer_idx)
+            return
+
+        # Cache miss: copy from pageable CPU
+        self._cache_misses += 1
+        gpu_w1_raw = self._raw_data(self.gpu_w1)
+        gpu_w2_raw = self._raw_data(self.gpu_w2)
+        gpu_w1_mx_raw = self._raw_data(self.gpu_w1_mx) if self.gpu_w1_mx is not None else None
+        gpu_w2_mx_raw = self._raw_data(self.gpu_w2_mx) if self.gpu_w2_mx is not None else None
+
         cpu_layer = self.cpu[layer_idx]
+        cpu_w1 = cpu_layer["w1"]
+        cpu_w1_mx = cpu_layer.get("w1_mx")
+        cpu_b1 = cpu_layer["b1"]
+        cpu_w2 = cpu_layer["w2"]
+        cpu_w2_mx = cpu_layer.get("w2_mx")
+        cpu_b2 = cpu_layer["b2"]
 
         for eid in expert_ids:
             eid_i = int(eid)
             if self.gpu_layer[eid_i] == layer_idx:
                 continue
-            cw = cpu_layer[eid_i]
 
-            # Pin source, copy, unpin — per tensor to keep pinned footprint tiny
-            _pin_cpu(cw["w1"])
-            gpu_w1_raw[eid_i].copy_(cw["w1"])
-            _unpin_cpu(cw["w1"])
+            gpu_w1_raw[eid_i].copy_(cpu_w1[eid_i])
 
-            if gpu_w1_mx_raw is not None and cw["w1_mx"] is not None:
-                _pin_cpu(cw["w1_mx"])
-                gpu_w1_mx_raw[eid_i].copy_(cw["w1_mx"])
-                _unpin_cpu(cw["w1_mx"])
+            if gpu_w1_mx_raw is not None and cpu_w1_mx is not None:
+                gpu_w1_mx_raw[eid_i].copy_(cpu_w1_mx[eid_i])
 
-            _pin_cpu(cw["b1"])
-            self.gpu_b1[eid_i].copy_(cw["b1"])
-            _unpin_cpu(cw["b1"])
+            self.gpu_b1[eid_i].copy_(cpu_b1[eid_i])
 
-            _pin_cpu(cw["w2"])
-            gpu_w2_raw[eid_i].copy_(cw["w2"])
-            _unpin_cpu(cw["w2"])
+            gpu_w2_raw[eid_i].copy_(cpu_w2[eid_i])
 
-            if gpu_w2_mx_raw is not None and cw["w2_mx"] is not None:
-                _pin_cpu(cw["w2_mx"])
-                gpu_w2_mx_raw[eid_i].copy_(cw["w2_mx"])
-                _unpin_cpu(cw["w2_mx"])
+            if gpu_w2_mx_raw is not None and cpu_w2_mx is not None:
+                gpu_w2_mx_raw[eid_i].copy_(cpu_w2_mx[eid_i])
 
-            _pin_cpu(cw["b2"])
-            self.gpu_b2[eid_i].copy_(cw["b2"])
-            _unpin_cpu(cw["b2"])
+            self.gpu_b2[eid_i].copy_(cpu_b2[eid_i])
 
             self.gpu_layer[eid_i] = layer_idx
 
     def load_all_experts(self, layer_idx: int) -> None:
-        """Load every expert for *layer_idx* into the GPU buffers (for prefill)."""
+        """Load every expert into the shared GPU buffers (for prefill)."""
         self.ensure_experts(layer_idx, list(range(self.num_experts)))
+
+    # ------------------------------------------------------------------
+    # Hot-layer GPU cache
+    # ------------------------------------------------------------------
+
+    def init_layer_cache(self, max_layers: int = 999) -> int:
+        """Determine how many full-layer GPU caches fit in free VRAM.
+
+        Must be called after all ``register_layer`` calls so that tensor
+        sizes are known.  Returns the actual number of cache slots
+        available.  Actual GPU allocation is deferred to ``cache_layer``.
+        """
+        gpu_w1_raw = self._raw_data(self.gpu_w1)
+        gpu_w2_raw = self._raw_data(self.gpu_w2)
+
+        total_bytes = (
+            gpu_w1_raw.numel() * gpu_w1_raw.element_size()
+            + gpu_w2_raw.numel() * gpu_w2_raw.element_size()
+            + self.gpu_b1.numel() * self.gpu_b1.element_size()
+            + self.gpu_b2.numel() * self.gpu_b2.element_size()
+        )
+        if self.gpu_w1_mx is not None:
+            total_bytes += self._raw_data(self.gpu_w1_mx).numel() * self._raw_data(self.gpu_w1_mx).element_size()
+        if self.gpu_w2_mx is not None:
+            total_bytes += self._raw_data(self.gpu_w2_mx).numel() * self._raw_data(self.gpu_w2_mx).element_size()
+
+        self._cache_bytes_per_layer = total_bytes
+
+        free, _ = torch.cuda.mem_get_info(self.device)
+        # Reserve 2 GB for KV cache, activations, CUDA graph workspace.
+        inference_headroom = 2 * 1024**3
+        usable = max(0, int(free) - inference_headroom)
+        self._cache_capacity = min(max_layers, max(0, usable // total_bytes))
+        if self._cache_capacity > 0:
+            print(f"[cache] {self._cache_capacity} layer slots "
+                  f"({self._cache_capacity * total_bytes / 1e9:.2f} GB) "
+                  f"from {usable / 1e9:.2f} GB usable VRAM")
+
+        # Deferred allocation — actual GPU tensors created in cache_layer
+        self._cache_order = [-1] * self._cache_capacity
+
+        return self._cache_capacity
+
+    def cache_layer(self, layer_idx: int) -> bool:
+        """Fill the GPU cache for *layer_idx* from CPU pageable storage.
+
+        Returns True if the layer was cached, False if cache is disabled
+        or the layer is already cached.
+        """
+        if self._cache_capacity == 0:
+            return False
+        if layer_idx in self._cache:
+            self._touch_cache(layer_idx)
+            return True
+
+        # Evict LRU layer if cache is full
+        if len(self._cache) >= self._cache_capacity:
+            evict_idx = self._cache_order[-1]
+            if evict_idx >= 0 and evict_idx in self._cache:
+                del self._cache[evict_idx]
+                self._cache_order[-1] = -1
+
+        # Find a free slot
+        slot = -1
+        for i, lid in enumerate(self._cache_order):
+            if lid < 0 or lid not in self._cache:
+                slot = i
+                break
+        if slot < 0:
+            slot = len(self._cache_order) - 1  # reuse last slot
+
+        # Allocate buffers in this slot if first use
+        if self._cache_order[slot] < 0:
+            # Already allocated in init_layer_cache; just assign
+            self._cache_order[slot] = layer_idx
+            self._cache[layer_idx] = {}  # filled below
+
+        # Copy all 128 experts from pageable CPU to GPU cache
+        cpu_layer = self.cpu[layer_idx]
+        cache_entry = self._cache.setdefault(layer_idx, {})
+        for key in ["w1", "w1_mx", "b1", "w2", "w2_mx", "b2"]:
+            if key in cpu_layer:
+                if key not in cache_entry:
+                    # Allocate on first use
+                    cache_entry[key] = cpu_layer[key].to(self.device)
+                else:
+                    cache_entry[key].copy_(cpu_layer[key])
+
+        self._touch_cache(layer_idx)
+        return True
+
+    def cache_stats(self) -> dict:
+        """Return cache hit/miss counters."""
+        total = self._cache_hits + self._cache_misses
+        return {
+            "hits": self._cache_hits,
+            "misses": self._cache_misses,
+            "hit_rate": self._cache_hits / total if total > 0 else 0.0,
+            "capacity": self._cache_capacity,
+            "active": len(self._cache),
+            "bytes_per_layer_mb": self._cache_bytes_per_layer / (1024 * 1024),
+        }
+
+    def _copy_from_cache(self, layer_idx: int) -> None:
+        """Copy all 128 experts from GPU cache → shared GPU buffers.
+
+        Six large contiguous GPU→GPU copies at ~900 GB/s, replacing
+        24 small pageable CPU→GPU copies at ~15 GB/s.
+        """
+        cache_entry = self._cache[layer_idx]
+        gpu_w1_raw = self._raw_data(self.gpu_w1)
+        gpu_w2_raw = self._raw_data(self.gpu_w2)
+
+        gpu_w1_raw.copy_(cache_entry["w1"])
+        if self.gpu_w1_mx is not None and "w1_mx" in cache_entry:
+            self._raw_data(self.gpu_w1_mx).copy_(cache_entry["w1_mx"])
+        self.gpu_b1.copy_(cache_entry["b1"])
+        gpu_w2_raw.copy_(cache_entry["w2"])
+        if self.gpu_w2_mx is not None and "w2_mx" in cache_entry:
+            self._raw_data(self.gpu_w2_mx).copy_(cache_entry["w2_mx"])
+        self.gpu_b2.copy_(cache_entry["b2"])
+
+        # Mark all 128 GPU slots as belonging to this layer
+        for eid in range(self.num_experts):
+            self.gpu_layer[eid] = layer_idx
+
+    def _touch_cache(self, layer_idx: int) -> None:
+        """Move *layer_idx* to the front of the LRU order."""
+        if layer_idx in self._cache_order:
+            self._cache_order.remove(layer_idx)
+        while len(self._cache_order) < self._cache_capacity:
+            self._cache_order.append(-1)
+        self._cache_order.insert(0, layer_idx)
+        # Trim to capacity
+        while len(self._cache_order) > self._cache_capacity:
+            removed = self._cache_order.pop()
+            if removed >= 0 and removed in self._cache:
+                del self._cache[removed]
 
     # ------------------------------------------------------------------
     # CUDA Graph (decode matmul)
@@ -244,22 +343,15 @@ class ExpertCache:
 
     def init_decode_graph(
         self,
-        rdata,           # RoutingData from triton_kernels.routing
-        gather_indx,     # GatherIndx
-        scatter_indx,    # ScatterIndx
+        rdata,
+        gather_indx,
+        scatter_indx,
         swiglu_limit: float = 7.0,
     ) -> None:
-        """Capture a CUDA graph for the decode-matmul path.
-
-        Called once after the first decode routing step.  The graph
-        captures ``moe_decode_experts`` reading from the shared GPU
-        buffers, so it can be replayed for every layer / every token
-        as long as the buffers are refreshed beforehand.
-        """
+        """Capture a CUDA graph for the decode-matmul path."""
         from triton_kernels.routing import GatherIndx, ScatterIndx, RoutingData, ExptData
         from .moe import moe_decode_experts
 
-        # Snapshot the routing tensors (these become the fixed-address proxies)
         self._g_topk = gather_indx.src_indx.clone()
         self._g_gate = gather_indx.dst_indx.clone()
         self._g_scale = rdata.gate_scal.clone()
@@ -284,7 +376,6 @@ class ExpertCache:
         self._g_gather = GatherIndx(src_indx=self._g_topk, dst_indx=self._g_gate)
         self._g_scatter = ScatterIndx(src_indx=self._g_gate, dst_indx=self._g_topk)
 
-        # Input buffer — same shape as the decode activation
         hidden_size = self.gpu_b2.shape[1]
         self._g_x = self.gpu_b2.new_zeros(1, hidden_size, dtype=torch.bfloat16)
 
@@ -299,23 +390,6 @@ class ExpertCache:
                 swiglu_limit=swiglu_limit,
             )
 
-    def update_graph_routing(
-        self,
-        rdata,
-        gather_indx,
-        scatter_indx,
-    ) -> None:
-        """Copy fresh routing results into the graph's proxy tensors."""
-        self._g_topk.copy_(gather_indx.src_indx)
-        self._g_gate.copy_(gather_indx.dst_indx)
-        self._g_scale.copy_(rdata.gate_scal)
-        self._g_hist.copy_(rdata.expt_hist)
-        self._g_offs_raw.copy_(rdata.expt_data.token_offs_raw)
-        for k in self._g_offs_pad:
-            self._g_offs_pad[k].copy_(rdata.expt_data.token_offs_pad[k])
-        for k in self._g_pid_map:
-            self._g_pid_map[k].copy_(rdata.expt_data.block_pid_map[k])
-
     # ------------------------------------------------------------------
     # CUDA Graph (decode gate routing)
     # ------------------------------------------------------------------
@@ -328,16 +402,9 @@ class ExpertCache:
         experts_per_token: int = 4,
         num_experts: int = 128,
     ) -> None:
-        """Capture a CUDA graph for the decode gate-routing path.
-
-        The graph replays ``moe_decode_gate_routing`` writing into
-        fixed-address proxy tensors.  Before each replay the caller
-        must copy the current layer's *t*, *wg*, *bg* into
-        ``_gr_t``, ``_gr_wg``, ``_gr_bg``.
-        """
+        """Capture a CUDA graph for the decode gate-routing path."""
         from .moe import moe_decode_gate_routing
 
-        # Pre-allocate input buffers
         self._gr_t = t.clone()
         self._gr_wg = wg.clone()
         self._gr_bg = bg.clone() if bg is not None else None
@@ -363,7 +430,7 @@ class ExpertCache:
             self._g_pid_map[k].copy_(self._gr_rdata.expt_data.block_pid_map[k])
 
     def free_gpu_buffers(self) -> None:
-        """Release all global GPU buffers to reclaim memory."""
+        """Release all GPU buffers to reclaim memory."""
         self.route_graph = None
         self.decode_graph = None
         self._gr_t = None
@@ -377,4 +444,6 @@ class ExpertCache:
         self.gpu_w2 = None
         self.gpu_w2_mx = None
         self.gpu_b2 = None
+        self._cache.clear()
+        self._cache_order.clear()
         self.gpu_layer = []

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -30,8 +30,11 @@ class ExpertCache:
         self.experts_per_token = experts_per_token
         self.device = device
 
-        # Per-layer pageable CPU storage — contiguous per-tensor
+        # Per-layer pageable CPU storage — contiguous per-tensor (FP4/uint8, swizzled)
         self.cpu: dict[int, dict[str, torch.Tensor]] = {}
+
+        # Per-layer simple (non-swizzled) FP4 CPU storage for CPU-side expert compute
+        self.cpu_fp4: dict[int, dict[str, torch.Tensor]] = {}
 
         # Global GPU buffers — the custom Tensor objects themselves
         self.gpu_w1 = None
@@ -81,10 +84,13 @@ class ExpertCache:
         w2,
         w2_mx,
         b2: torch.Tensor,
+        store_cpu: bool = True,
     ) -> None:
-        """Store pageable CPU copies and initialise shared GPU buffers.
+        """Initialise shared GPU buffers, optionally store pageable CPU copies.
 
         Called once per MLP layer after weight loading + quantization.
+        When ``store_cpu=False``, only the GPU buffers are set up (first call)
+        and CPU storage is skipped to save memory.
         """
         if self.gpu_w1 is None:
             self.gpu_w1 = w1
@@ -99,12 +105,101 @@ class ExpertCache:
             )
             self.gpu_layer = [-1] * self.num_experts
 
-        # Store pageable CPU tensors — one contiguous tensor per component,
-        # shape (num_experts, ...), matching the GPU buffer layout.
-        cpu_layer: dict[str, torch.Tensor] = {}
-        for key, gpu_tensor in self._iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
-            cpu_layer[key] = self._gpu_to_pageable_cpu(gpu_tensor)
-        self.cpu[layer_idx] = cpu_layer
+        if store_cpu:
+            cpu_layer: dict[str, torch.Tensor] = {}
+            for key, gpu_tensor in self._iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
+                cpu_layer[key] = self._gpu_to_pageable_cpu(gpu_tensor)
+            self.cpu[layer_idx] = cpu_layer
+
+    def register_cpu_fp4(
+        self,
+        layer_idx: int,
+        w1_fp4: torch.Tensor,
+        w1_scale: torch.Tensor,
+        b1: torch.Tensor,
+        w2_fp4: torch.Tensor,
+        w2_scale: torch.Tensor,
+        b2: torch.Tensor,
+    ) -> None:
+        """Store simple (non-swizzled) FP4 weights on CPU.
+
+        These are used for CPU-side expert computation: only the 4 activated
+        experts are dequantized on-the-fly per layer per token.
+        """
+        self.cpu_fp4[layer_idx] = {
+            "w1": w1_fp4.detach().cpu(),
+            "w1_scale": w1_scale.detach().cpu(),
+            "b1": b1.detach().cpu(),
+            "w2": w2_fp4.detach().cpu(),
+            "w2_scale": w2_scale.detach().cpu(),
+            "b2": b2.detach().cpu(),
+        }
+
+    # ------------------------------------------------------------------
+    # CPU-side expert forward (decode, batch=1)
+    # ------------------------------------------------------------------
+
+    @torch.inference_mode()
+    def cpu_expert_forward(
+        self,
+        layer_idx: int,
+        x: torch.Tensor,
+        expert_ids: list[int],
+        gate_weights: torch.Tensor,
+        swiglu_limit: float = 7.0,
+    ) -> torch.Tensor:
+        """Compute expert MLP on CPU, return result on GPU.
+
+        Dequantizes only the activated experts' FP4 weights to BF16 on
+        CPU, computes the matmuls, then discards the temporary BF16.
+        Total data read from CPU RAM: ~25 MB per layer (4 × ~6.3 MB FP4).
+        """
+        from triton_kernels.numerics_details.mxfp import upcast_from_mxfp_torch
+
+        fp4 = self.cpu_fp4[layer_idx]
+        device = x.device
+        hidden = x.shape[1]
+
+        x_cpu = x.cpu()  # [1, hidden] bf16 → CPU
+        result = torch.zeros(1, hidden, dtype=torch.float32)
+
+        for i, eid in enumerate(expert_ids):
+            eid_i = int(eid)
+
+            # Dequantize FP4 → BF16 for this expert
+            w1_bf16 = upcast_from_mxfp_torch(
+                fp4["w1"][eid_i], fp4["w1_scale"][eid_i],
+                torch.bfloat16, axis=0,
+            )  # [intermediate, hidden*2]
+            w2_bf16 = upcast_from_mxfp_torch(
+                fp4["w2"][eid_i], fp4["w2_scale"][eid_i],
+                torch.bfloat16, axis=0,
+            )  # [hidden, intermediate]
+
+            intermediate = w1_bf16.shape[0]
+
+            # ---- gate + up matmul ----
+            w1_e = (
+                w1_bf16
+                .reshape(intermediate, 2, hidden)
+                .permute(1, 0, 2)
+                .reshape(intermediate * 2, hidden)
+            )
+            b1_e = fp4["b1"][eid_i]
+            gate_up = torch.nn.functional.linear(x_cpu, w1_e, b1_e)
+
+            # SiLU gate
+            gate, up = gate_up.chunk(2, dim=-1)
+            gate = gate.clamp(-swiglu_limit, swiglu_limit)
+            activated = torch.nn.functional.silu(gate) * up
+
+            # ---- down matmul ----
+            b2_e = fp4["b2"][eid_i]
+            down = torch.nn.functional.linear(activated, w2_bf16, b2_e)
+
+            result += down * float(gate_weights[i])
+
+        return result.to(device=device, dtype=torch.bfloat16)
 
     def _gpu_to_pageable_cpu(self, gpu_tensor) -> torch.Tensor:
         """Copy the entire GPU tensor into a contiguous pageable CPU tensor."""

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -1,9 +1,14 @@
 """CPU/GPU hybrid expert weight cache for MoE models.
 
-Stores MoE expert weights on CPU (pageable, contiguous per-tensor) and
-maintains shared GPU buffers that are filled on-demand as each layer's
-experts are activated.  Only the activated experts (4/128) are transferred
-per layer.
+Stores MoE expert weights on CPU and maintains a shared set of GPU buffers
+that are filled on-demand as each layer's experts are activated. The routing
+step tells us exactly which experts are needed before the heavy matmul, so
+we only transfer the activated experts (4/128) per layer.
+
+The custom Tensor types from ``quantize_mx4`` do not expose ``cpu()`` or
+``clone()`` directly, so we work with the underlying ``torch.Tensor`` via
+``.storage.data``.  The swizzled layouts preserve the leading (expert)
+dimension, so ``storage.data[eid]`` correctly isolates a single expert.
 """
 
 from typing import Optional
@@ -14,10 +19,10 @@ import torch
 class ExpertCache:
     """Global GPU buffers for expert weights, shared across all layers.
 
-    Each layer's expert weights are stored on CPU as contiguous pageable
-    tensors whose layout matches the GPU buffers (``(num_experts, ...)``).
-    Before each MLP forward the activated experts for that layer are copied
-    from CPU into the corresponding GPU slots.
+    Each layer's expert weights are stored on CPU (per-expert slices of the
+    raw storage).  A single set of ``(num_experts, ...)`` shaped GPU buffers
+    is shared across layers — before each MLP forward the activated experts
+    for that layer are copied from CPU into the corresponding GPU slots.
     """
 
     def __init__(
@@ -30,46 +35,44 @@ class ExpertCache:
         self.experts_per_token = experts_per_token
         self.device = device
 
-        # Per-layer pageable CPU storage — contiguous per-tensor (FP4/uint8, swizzled)
-        self.cpu: dict[int, dict[str, torch.Tensor]] = {}
-
-        # Per-layer simple (non-swizzled) FP4 CPU storage for CPU-side expert compute
-        self.cpu_fp4: dict[int, dict[str, torch.Tensor]] = {}
+        # Per-layer, per-expert CPU storage (raw torch.Tensor slices)
+        # cpu[layer_idx][expert_id] = {"w1": Tensor, "w1_mx": Tensor, ...}
+        self.cpu: dict[int, dict[int, dict[str, torch.Tensor]]] = {}
 
         # Global GPU buffers — the custom Tensor objects themselves
-        self.gpu_w1 = None
-        self.gpu_w1_mx = None
-        self.gpu_b1: Optional[torch.Tensor] = None
-        self.gpu_w2 = None
-        self.gpu_w2_mx = None
-        self.gpu_b2: Optional[torch.Tensor] = None
+        self.gpu_w1 = None           # custom Tensor from quantize_mx4
+        self.gpu_w1_mx = None        # custom Tensor (or None)
+        self.gpu_b1: Optional[torch.Tensor] = None  # fp32 (E, intermed*2)
+        self.gpu_w2 = None           # custom Tensor
+        self.gpu_w2_mx = None        # custom Tensor (or None)
+        self.gpu_b2: Optional[torch.Tensor] = None  # fp32 (E, hidden)
 
-        # Track which layer is in each GPU slot
-        self.gpu_layer: list[int] = []
+        # Track which layer's data is currently in each GPU expert slot (CPU-side)
+        self.gpu_layer: list[int] = []  # [layer_idx] * num_experts, -1 = invalid
 
-        # ---- CUDA Graph: gate routing ----
+        # Per-layer CUDA graph: gate routing (captured once, shared across layers)
         self.route_graph: torch.cuda.CUDAGraph | None = None
-        self._gr_t: torch.Tensor | None = None
-        self._gr_wg: torch.Tensor | None = None
-        self._gr_bg: torch.Tensor | None = None
-        self._gr_rdata = None
-        self._gr_gather = None
-        self._gr_scatter = None
+        self._gr_t: torch.Tensor | None = None        # input activation buffer
+        self._gr_wg: torch.Tensor | None = None        # gate weight buffer
+        self._gr_bg: torch.Tensor | None = None        # gate bias buffer
+        self._gr_rdata = None   # RoutingData output (set during capture)
+        self._gr_gather = None  # GatherIndx output
+        self._gr_scatter = None # ScatterIndx output
 
-        # ---- CUDA Graph: decode matmul ----
+        # Per-layer CUDA graph for decode matmul (captured once, shared across layers)
         self.decode_graph: torch.cuda.CUDAGraph | None = None
-        self._g_x: torch.Tensor | None = None
-        self._g_out: torch.Tensor | None = None
-        self._g_topk: torch.Tensor | None = None
-        self._g_gate: torch.Tensor | None = None
-        self._g_scale: torch.Tensor | None = None
-        self._g_hist: torch.Tensor | None = None
-        self._g_offs_raw: torch.Tensor | None = None
+        self._g_x: torch.Tensor | None = None       # input activation buffer
+        self._g_out: torch.Tensor | None = None      # output activation (set during capture)
+        self._g_topk: torch.Tensor | None = None     # gather.src_indx / scatter.dst_indx
+        self._g_gate: torch.Tensor | None = None     # gather.dst_indx / scatter.src_indx
+        self._g_scale: torch.Tensor | None = None    # gate_scal
+        self._g_hist: torch.Tensor | None = None     # expt_hist
+        self._g_offs_raw: torch.Tensor | None = None # token_offs_raw
         self._g_offs_pad: dict[int, torch.Tensor] = {}
         self._g_pid_map: dict[int, torch.Tensor] = {}
-        self._g_rdata = None
-        self._g_gather = None
-        self._g_scatter = None
+        self._g_rdata = None   # proxy RoutingData
+        self._g_gather = None  # proxy GatherIndx
+        self._g_scatter = None # proxy ScatterIndx
 
     # ------------------------------------------------------------------
     # Registration
@@ -78,20 +81,18 @@ class ExpertCache:
     def register_layer(
         self,
         layer_idx: int,
-        w1,
-        w1_mx,
-        b1: torch.Tensor,
-        w2,
-        w2_mx,
-        b2: torch.Tensor,
-        store_cpu: bool = True,
+        w1,           # custom Tensor from quantize_mx4, shape (E, ...)
+        w1_mx,        # MXFP4 scales, shape (E, ...) — custom Tensor or None
+        b1: torch.Tensor,   # (E, intermediate_size*2) bf16
+        w2,           # custom Tensor, shape (E, ...)
+        w2_mx,        # MXFP4 scales
+        b2: torch.Tensor,   # (E, hidden_size) bf16
     ) -> None:
-        """Initialise shared GPU buffers, optionally store pageable CPU copies.
+        """Store per-expert CPU copies and initialise global GPU buffers.
 
         Called once per MLP layer after weight loading + quantization.
-        When ``store_cpu=False``, only the GPU buffers are set up (first call)
-        and CPU storage is skipped to save memory.
         """
+        # Allocate global GPU buffers on first call (keep first layer's tensors)
         if self.gpu_w1 is None:
             self.gpu_w1 = w1
             self.gpu_w1_mx = w1_mx if w1_mx is not None else None
@@ -105,170 +106,71 @@ class ExpertCache:
             )
             self.gpu_layer = [-1] * self.num_experts
 
-        if store_cpu:
-            cpu_layer: dict[str, torch.Tensor] = {}
-            for key, gpu_tensor in self._iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
-                cpu_layer[key] = self._gpu_to_pageable_cpu(gpu_tensor)
-            self.cpu[layer_idx] = cpu_layer
-
-    def register_cpu_fp4(
-        self,
-        layer_idx: int,
-        w1_fp4: torch.Tensor,
-        w1_scale: torch.Tensor,
-        b1: torch.Tensor,
-        w2_fp4: torch.Tensor,
-        w2_scale: torch.Tensor,
-        b2: torch.Tensor,
-    ) -> None:
-        """Store simple (non-swizzled) FP4 weights on CPU.
-
-        These are used for CPU-side expert computation: only the 4 activated
-        experts are dequantized on-the-fly per layer per token.
-        """
-        self.cpu_fp4[layer_idx] = {
-            "w1": w1_fp4.detach().cpu(),
-            "w1_scale": w1_scale.detach().cpu(),
-            "b1": b1.detach().cpu(),
-            "w2": w2_fp4.detach().cpu(),
-            "w2_scale": w2_scale.detach().cpu(),
-            "b2": b2.detach().cpu(),
-        }
-
-    # ------------------------------------------------------------------
-    # CPU-side expert forward (decode, batch=1)
-    # ------------------------------------------------------------------
-
-    @torch.inference_mode()
-    def cpu_expert_forward(
-        self,
-        layer_idx: int,
-        x: torch.Tensor,
-        expert_ids: list[int],
-        gate_weights: torch.Tensor,
-        swiglu_limit: float = 7.0,
-    ) -> torch.Tensor:
-        """Compute expert MLP on CPU, return result on GPU.
-
-        Dequantizes only the activated experts' FP4 weights to BF16 on
-        CPU, computes the matmuls, then discards the temporary BF16.
-        Total data read from CPU RAM: ~25 MB per layer (4 × ~6.3 MB FP4).
-        """
-        from triton_kernels.numerics_details.mxfp import upcast_from_mxfp_torch
-
-        fp4 = self.cpu_fp4[layer_idx]
-        device = x.device
-        hidden = x.shape[1]
-
-        x_cpu = x.cpu()  # [1, hidden] bf16 → CPU
-        result = torch.zeros(1, hidden, dtype=torch.float32)
-
-        for i, eid in enumerate(expert_ids):
-            eid_i = int(eid)
-
-            # Dequantize FP4 → BF16 for this expert
-            w1_bf16 = upcast_from_mxfp_torch(
-                fp4["w1"][eid_i], fp4["w1_scale"][eid_i],
-                torch.bfloat16, axis=0,
-            )  # [intermediate, hidden*2]
-            w2_bf16 = upcast_from_mxfp_torch(
-                fp4["w2"][eid_i], fp4["w2_scale"][eid_i],
-                torch.bfloat16, axis=0,
-            )  # [hidden, intermediate]
-
-            intermediate = w1_bf16.shape[0]
-
-            # ---- gate + up matmul ----
-            w1_e = (
-                w1_bf16
-                .reshape(intermediate, 2, hidden)
-                .permute(1, 0, 2)
-                .reshape(intermediate * 2, hidden)
-            )
-            b1_e = fp4["b1"][eid_i]
-            gate_up = torch.nn.functional.linear(x_cpu, w1_e, b1_e)
-
-            # SiLU gate
-            gate, up = gate_up.chunk(2, dim=-1)
-            gate = gate.clamp(-swiglu_limit, swiglu_limit)
-            activated = torch.nn.functional.silu(gate) * up
-
-            # ---- down matmul ----
-            b2_e = fp4["b2"][eid_i]
-            down = torch.nn.functional.linear(activated, w2_bf16, b2_e)
-
-            result += down * float(gate_weights[i])
-
-        return result.to(device=device, dtype=torch.bfloat16)
-
-    def _gpu_to_pageable_cpu(self, gpu_tensor) -> torch.Tensor:
-        """Copy the entire GPU tensor into a contiguous pageable CPU tensor."""
-        raw = self._raw_data(gpu_tensor)
-        return raw.cpu()
+        # Slice by expert and move to CPU (via .storage.data for custom Tensors)
+        cpu_layer: dict[int, dict[str, torch.Tensor]] = {}
+        for eid in range(self.num_experts):
+            cpu_layer[eid] = {
+                "w1": self._raw_slice_cpu(w1, eid),
+                "w1_mx": self._raw_slice_cpu(w1_mx, eid)
+                if w1_mx is not None else None,
+                "b1": b1[eid].cpu(),
+                "w2": self._raw_slice_cpu(w2, eid),
+                "w2_mx": self._raw_slice_cpu(w2_mx, eid)
+                if w2_mx is not None else None,
+                "b2": b2[eid].cpu(),
+            }
+        self.cpu[layer_idx] = cpu_layer
 
     @staticmethod
-    def _raw_data(tensor) -> torch.Tensor:
-        """Return the underlying torch.Tensor for a regular or custom Tensor."""
+    def _raw_slice_cpu(tensor, index: int) -> torch.Tensor:
+        """Slice *tensor* at *index* and move the slice to CPU.
+
+        Works with both regular ``torch.Tensor`` and the custom ``Tensor``
+        from ``triton_kernels.tensor`` (by accessing ``.storage.data``).
+        """
         if hasattr(tensor, "storage") and hasattr(tensor.storage, "data"):
-            return tensor.storage.data
-        return tensor
-
-    @staticmethod
-    def _iter_tensors(w1, w1_mx, b1, w2, w2_mx, b2):
-        for key, t in [
-            ("w1", w1), ("w1_mx", w1_mx), ("b1", b1),
-            ("w2", w2), ("w2_mx", w2_mx), ("b2", b2),
-        ]:
-            if t is not None:
-                yield key, t
+            raw = tensor.storage.data  # underlying torch.Tensor
+        else:
+            raw = tensor
+        return raw[index].cpu()
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
-        """Copy expert weights from CPU → GPU if not already present.
-
-        CPU storage is contiguous per-tensor (shape ``(num_experts, ...)``),
-        so each ``cpu_tensor[eid]`` is a contiguous slice that maps directly
-        to the corresponding GPU slot.
-        """
-        gpu_w1_raw = self._raw_data(self.gpu_w1)
-        gpu_w2_raw = self._raw_data(self.gpu_w2)
-        gpu_w1_mx_raw = self._raw_data(self.gpu_w1_mx) if self.gpu_w1_mx is not None else None
-        gpu_w2_mx_raw = self._raw_data(self.gpu_w2_mx) if self.gpu_w2_mx is not None else None
-
+        """Synchronously copy expert weights from CPU → GPU if not already present."""
+        gpu_w1_raw = self.gpu_w1.storage.data
+        gpu_w2_raw = self.gpu_w2.storage.data
+        gpu_w1_mx_raw = (
+            self.gpu_w1_mx.storage.data
+            if self.gpu_w1_mx is not None and hasattr(self.gpu_w1_mx, "storage")
+            else self.gpu_w1_mx
+        )
+        gpu_w2_mx_raw = (
+            self.gpu_w2_mx.storage.data
+            if self.gpu_w2_mx is not None and hasattr(self.gpu_w2_mx, "storage")
+            else self.gpu_w2_mx
+        )
         cpu_layer = self.cpu[layer_idx]
-        cpu_w1 = cpu_layer["w1"]
-        cpu_w1_mx = cpu_layer.get("w1_mx")
-        cpu_b1 = cpu_layer["b1"]
-        cpu_w2 = cpu_layer["w2"]
-        cpu_w2_mx = cpu_layer.get("w2_mx")
-        cpu_b2 = cpu_layer["b2"]
 
         for eid in expert_ids:
             eid_i = int(eid)
             if self.gpu_layer[eid_i] == layer_idx:
                 continue
-
-            gpu_w1_raw[eid_i].copy_(cpu_w1[eid_i])
-
-            if gpu_w1_mx_raw is not None and cpu_w1_mx is not None:
-                gpu_w1_mx_raw[eid_i].copy_(cpu_w1_mx[eid_i])
-
-            self.gpu_b1[eid_i].copy_(cpu_b1[eid_i])
-
-            gpu_w2_raw[eid_i].copy_(cpu_w2[eid_i])
-
-            if gpu_w2_mx_raw is not None and cpu_w2_mx is not None:
-                gpu_w2_mx_raw[eid_i].copy_(cpu_w2_mx[eid_i])
-
-            self.gpu_b2[eid_i].copy_(cpu_b2[eid_i])
-
+            cw = cpu_layer[eid_i]
+            gpu_w1_raw[eid_i].copy_(cw["w1"])
+            if gpu_w1_mx_raw is not None and cw["w1_mx"] is not None:
+                gpu_w1_mx_raw[eid_i].copy_(cw["w1_mx"])
+            self.gpu_b1[eid_i].copy_(cw["b1"])
+            gpu_w2_raw[eid_i].copy_(cw["w2"])
+            if gpu_w2_mx_raw is not None and cw["w2_mx"] is not None:
+                gpu_w2_mx_raw[eid_i].copy_(cw["w2_mx"])
+            self.gpu_b2[eid_i].copy_(cw["b2"])
             self.gpu_layer[eid_i] = layer_idx
 
     def load_all_experts(self, layer_idx: int) -> None:
-        """Load every expert into the shared GPU buffers (for prefill)."""
+        """Load every expert for *layer_idx* into the GPU buffers (for prefill)."""
         self.ensure_experts(layer_idx, list(range(self.num_experts)))
 
     # ------------------------------------------------------------------
@@ -277,15 +179,22 @@ class ExpertCache:
 
     def init_decode_graph(
         self,
-        rdata,
-        gather_indx,
-        scatter_indx,
+        rdata,           # RoutingData from triton_kernels.routing
+        gather_indx,     # GatherIndx
+        scatter_indx,    # ScatterIndx
         swiglu_limit: float = 7.0,
     ) -> None:
-        """Capture a CUDA graph for the decode-matmul path."""
+        """Capture a CUDA graph for the decode-matmul path.
+
+        Called once after the first decode routing step.  The graph
+        captures ``moe_decode_experts`` reading from the shared GPU
+        buffers, so it can be replayed for every layer / every token
+        as long as the buffers are refreshed beforehand.
+        """
         from triton_kernels.routing import GatherIndx, ScatterIndx, RoutingData, ExptData
         from .moe import moe_decode_experts
 
+        # Snapshot the routing tensors (these become the fixed-address proxies)
         self._g_topk = gather_indx.src_indx.clone()
         self._g_gate = gather_indx.dst_indx.clone()
         self._g_scale = rdata.gate_scal.clone()
@@ -310,6 +219,7 @@ class ExpertCache:
         self._g_gather = GatherIndx(src_indx=self._g_topk, dst_indx=self._g_gate)
         self._g_scatter = ScatterIndx(src_indx=self._g_gate, dst_indx=self._g_topk)
 
+        # Input buffer — same shape as the decode activation
         hidden_size = self.gpu_b2.shape[1]
         self._g_x = self.gpu_b2.new_zeros(1, hidden_size, dtype=torch.bfloat16)
 
@@ -324,6 +234,23 @@ class ExpertCache:
                 swiglu_limit=swiglu_limit,
             )
 
+    def update_graph_routing(
+        self,
+        rdata,
+        gather_indx,
+        scatter_indx,
+    ) -> None:
+        """Copy fresh routing results into the graph's proxy tensors."""
+        self._g_topk.copy_(gather_indx.src_indx)
+        self._g_gate.copy_(gather_indx.dst_indx)
+        self._g_scale.copy_(rdata.gate_scal)
+        self._g_hist.copy_(rdata.expt_hist)
+        self._g_offs_raw.copy_(rdata.expt_data.token_offs_raw)
+        for k in self._g_offs_pad:
+            self._g_offs_pad[k].copy_(rdata.expt_data.token_offs_pad[k])
+        for k in self._g_pid_map:
+            self._g_pid_map[k].copy_(rdata.expt_data.block_pid_map[k])
+
     # ------------------------------------------------------------------
     # CUDA Graph (decode gate routing)
     # ------------------------------------------------------------------
@@ -336,9 +263,16 @@ class ExpertCache:
         experts_per_token: int = 4,
         num_experts: int = 128,
     ) -> None:
-        """Capture a CUDA graph for the decode gate-routing path."""
+        """Capture a CUDA graph for the decode gate-routing path.
+
+        The graph replays ``moe_decode_gate_routing`` writing into
+        fixed-address proxy tensors.  Before each replay the caller
+        must copy the current layer's *t*, *wg*, *bg* into
+        ``_gr_t``, ``_gr_wg``, ``_gr_bg``.
+        """
         from .moe import moe_decode_gate_routing
 
+        # Pre-allocate input buffers
         self._gr_t = t.clone()
         self._gr_wg = wg.clone()
         self._gr_bg = bg.clone() if bg is not None else None
@@ -364,7 +298,7 @@ class ExpertCache:
             self._g_pid_map[k].copy_(self._gr_rdata.expt_data.block_pid_map[k])
 
     def free_gpu_buffers(self) -> None:
-        """Release all GPU buffers to reclaim memory."""
+        """Release all global GPU buffers to reclaim memory."""
         self.route_graph = None
         self.decode_graph = None
         self._gr_t = None

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -55,6 +55,10 @@ class ExpertCache:
         self.gpu_cache: dict[int, dict[str, torch.Tensor]] = {}
         self._cache_bytes_per_layer: int = 0
 
+        # Hit/miss counters for gpu_layer reuse across tokens
+        self._hit_count: int = 0
+        self._miss_count: int = 0
+
         # Per-layer CUDA graph: gate routing (captured once, shared across layers)
         self.route_graph: torch.cuda.CUDAGraph | None = None
         self._gr_t: torch.Tensor | None = None        # input activation buffer
@@ -222,7 +226,10 @@ class ExpertCache:
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
         """Copy expert weights to GPU shared buffers if not already present.
 
-        Uses GPU→GPU D2D copy for hot-cached layers, CPU→GPU copy otherwise.
+        Two-path lookup:
+        1. Hot-layer cache: entire layer permanently on GPU → D2D copy
+        2. CPU→GPU copy: skips experts whose slot already holds this layer's data
+           (retained from a previous token), tracked via gpu_layer.
         """
         gpu_w1_raw = self.gpu_w1.storage.data
         gpu_w2_raw = self.gpu_w2.storage.data
@@ -237,9 +244,9 @@ class ExpertCache:
             else self.gpu_w2_mx
         )
 
+        # Path 1: hot-layer cache
         cached = self.gpu_cache.get(layer_idx)
         if cached is not None:
-            # Hot-layer path: D2D copy from permanent GPU cache
             cw1 = cached["w1"]
             cw1_mx = cached["w1_mx"]
             cb1 = cached["b1"]
@@ -261,22 +268,33 @@ class ExpertCache:
                 self.gpu_layer[eid_i] = layer_idx
             return
 
-        # Cold-layer path: CPU→GPU copy from pageable CPU storage
+        # Path 2: CPU→GPU copy, skipping experts already resident from previous tokens
         cpu_layer = self.cpu[layer_idx]
+
         for eid in expert_ids:
             eid_i = int(eid)
             if self.gpu_layer[eid_i] == layer_idx:
+                self._hit_count += 1
                 continue
+            self._miss_count += 1
             cw = cpu_layer[eid_i]
             gpu_w1_raw[eid_i].copy_(cw["w1"])
-            if gpu_w1_mx_raw is not None and cw["w1_mx"] is not None:
+            if gpu_w1_mx_raw is not None and cw.get("w1_mx") is not None:
                 gpu_w1_mx_raw[eid_i].copy_(cw["w1_mx"])
             self.gpu_b1[eid_i].copy_(cw["b1"])
             gpu_w2_raw[eid_i].copy_(cw["w2"])
-            if gpu_w2_mx_raw is not None and cw["w2_mx"] is not None:
+            if gpu_w2_mx_raw is not None and cw.get("w2_mx") is not None:
                 gpu_w2_mx_raw[eid_i].copy_(cw["w2_mx"])
             self.gpu_b2[eid_i].copy_(cw["b2"])
             self.gpu_layer[eid_i] = layer_idx
+
+    def reset_hit_rate(self) -> None:
+        self._hit_count = 0
+        self._miss_count = 0
+
+    def hit_rate(self) -> float:
+        total = self._hit_count + self._miss_count
+        return self._hit_count / total if total > 0 else 0.0
 
     def load_all_experts(self, layer_idx: int) -> None:
         """Load every expert for *layer_idx* into the GPU buffers (for prefill)."""

--- a/tritonllm/gpt_oss/triton/expert_cache.py
+++ b/tritonllm/gpt_oss/triton/expert_cache.py
@@ -59,6 +59,21 @@ class ExpertCache:
         self._hit_count: int = 0
         self._miss_count: int = 0
 
+        # Victim cache: manually-managed GPU buffer for evicted expert data.
+        # When a GPU slot is overwritten by a different layer, the old data is
+        # saved here.  On a later reuse, a D2D copy (~900 GB/s) restores it.
+        self._vc_slots: int = 0
+        self._vc_w1: torch.Tensor | None = None
+        self._vc_w1_mx: torch.Tensor | None = None
+        self._vc_b1: torch.Tensor | None = None
+        self._vc_w2: torch.Tensor | None = None
+        self._vc_w2_mx: torch.Tensor | None = None
+        self._vc_b2: torch.Tensor | None = None
+        self._vc_expert_shapes: dict | None = None  # set on first register_layer
+        self._vc_tag: dict[tuple[int, int], int] = {}  # (layer, expert) → slot idx
+        self._vc_free: list[int] = []   # free slot indices
+        self._vc_lru: list[int] = []    # front=LRU, back=MRU
+
         # Per-layer CUDA graph: gate routing (captured once, shared across layers)
         self.route_graph: torch.cuda.CUDAGraph | None = None
         self._gr_t: torch.Tensor | None = None        # input activation buffer
@@ -133,6 +148,19 @@ class ExpertCache:
                 (w2_mx_raw.numel() * w2_mx_raw.element_size() if w2_mx_raw is not None else 0)
             )
 
+            # Save per-expert shapes for deferred victim cache allocation
+            self._vc_expert_shapes = {
+                "w1": w1_raw.shape[1:], "w1_dtype": w1_raw.dtype,
+                "w1_mx": w1_mx_raw.shape[1:] if w1_mx_raw is not None else None,
+                "w1_mx_dtype": w1_mx_raw.dtype if w1_mx_raw is not None else None,
+                "b1": b1_f32.shape[1:],
+                "w2": w2_raw.shape[1:], "w2_dtype": w2_raw.dtype,
+                "w2_mx": w2_mx_raw.shape[1:] if w2_mx_raw is not None else None,
+                "w2_mx_dtype": w2_mx_raw.dtype if w2_mx_raw is not None else None,
+                "b2": b2_f32.shape[1:],
+                "bytes_per_expert": self._cache_bytes_per_layer // self.num_experts,
+            }
+
         if cache_on_gpu:
             # Keep raw tensors on GPU for fast D2D copies
             self.gpu_cache[layer_idx] = {
@@ -193,6 +221,108 @@ class ExpertCache:
         return raw[index].cpu()
 
     # ------------------------------------------------------------------
+    # Victim cache — manually managed GPU memory
+    # ------------------------------------------------------------------
+
+    def init_victim_cache(self, max_slots: int = 200) -> int:
+        """Pre-allocate a contiguous GPU buffer for evicted expert data.
+
+        Must be called AFTER model loading is complete (sufficient free VRAM).
+        Returns the number of allocated cache slots.
+        """
+        if self._vc_expert_shapes is None:
+            return 0
+        s = self._vc_expert_shapes
+        expert_bytes = s["bytes_per_expert"]
+        free, _ = torch.cuda.mem_get_info()
+        usable = max(0, free - 2.5 * 1024**3)  # reserve 2.5 GB for kernels, KV cache, etc.
+        slots = min(int(usable // expert_bytes), max_slots)
+        if slots < self.experts_per_token:
+            print(f"Victim cache: insufficient VRAM "
+                  f"(need {expert_bytes * self.experts_per_token / 1e9:.2f} GB, "
+                  f"have {usable / 1e9:.2f} GB usable). Victim cache disabled.")
+            return 0
+
+        self._vc_slots = slots
+        self._vc_w1 = torch.empty(slots, *s["w1"], dtype=s["w1_dtype"], device=self.device)
+        self._vc_w1_mx = (
+            torch.empty(slots, *s["w1_mx"], dtype=s["w1_mx_dtype"], device=self.device)
+            if s["w1_mx"] is not None else None
+        )
+        self._vc_b1 = torch.empty(slots, *s["b1"], dtype=torch.float32, device=self.device)
+        self._vc_w2 = torch.empty(slots, *s["w2"], dtype=s["w2_dtype"], device=self.device)
+        self._vc_w2_mx = (
+            torch.empty(slots, *s["w2_mx"], dtype=s["w2_mx_dtype"], device=self.device)
+            if s["w2_mx"] is not None else None
+        )
+        self._vc_b2 = torch.empty(slots, *s["b2"], dtype=torch.float32, device=self.device)
+        self._vc_free = list(range(slots))
+        self._vc_tag = {}
+        self._vc_lru = []
+        vc_bytes = slots * expert_bytes
+        print(f"Victim cache: {slots} slots ({vc_bytes / 1e9:.2f} GB, "
+              f"{vc_bytes / 1024**3:.2f} GiB)")
+        return slots
+
+    def _vc_evict_one(self) -> int:
+        """Evict the LRU entry, returning its slot index."""
+        slot = self._vc_lru.pop(0)
+        # Find and remove the tag pointing to this slot
+        for key, s in list(self._vc_tag.items()):
+            if s == slot:
+                del self._vc_tag[key]
+                break
+        return slot
+
+    def _vc_put(self, layer_idx: int, eid_i: int,
+                w1_src, w1_mx_src, b1_src, w2_src, w2_mx_src, b2_src):
+        """Save expert data into the victim cache before it gets overwritten."""
+        key = (layer_idx, eid_i)
+        if key in self._vc_tag:
+            # Already cached — update LRU position
+            slot = self._vc_tag[key]
+            if slot in self._vc_lru:
+                self._vc_lru.remove(slot)
+            self._vc_lru.append(slot)
+            # Still need to refresh the data since shared buffer may have changed
+        else:
+            slot = self._vc_free.pop() if self._vc_free else self._vc_evict_one()
+            self._vc_tag[key] = slot
+            if slot in self._vc_lru:
+                self._vc_lru.remove(slot)
+            self._vc_lru.append(slot)
+
+        self._vc_w1[slot].copy_(w1_src)
+        if self._vc_w1_mx is not None and w1_mx_src is not None:
+            self._vc_w1_mx[slot].copy_(w1_mx_src)
+        self._vc_b1[slot].copy_(b1_src)
+        self._vc_w2[slot].copy_(w2_src)
+        if self._vc_w2_mx is not None and w2_mx_src is not None:
+            self._vc_w2_mx[slot].copy_(w2_mx_src)
+        self._vc_b2[slot].copy_(b2_src)
+
+    def _vc_get(self, layer_idx: int, eid_i: int,
+                w1_dst, w1_mx_dst, b1_dst, w2_dst, w2_mx_dst, b2_dst) -> bool:
+        """Restore expert data from victim cache. Returns True on hit."""
+        key = (layer_idx, eid_i)
+        slot = self._vc_tag.get(key)
+        if slot is None:
+            return False
+        w1_dst.copy_(self._vc_w1[slot])
+        if w1_mx_dst is not None and self._vc_w1_mx is not None:
+            w1_mx_dst.copy_(self._vc_w1_mx[slot])
+        b1_dst.copy_(self._vc_b1[slot])
+        w2_dst.copy_(self._vc_w2[slot])
+        if w2_mx_dst is not None and self._vc_w2_mx is not None:
+            w2_mx_dst.copy_(self._vc_w2_mx[slot])
+        b2_dst.copy_(self._vc_b2[slot])
+        # Update LRU
+        if slot in self._vc_lru:
+            self._vc_lru.remove(slot)
+        self._vc_lru.append(slot)
+        return True
+
+    # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
@@ -226,10 +356,11 @@ class ExpertCache:
     def ensure_experts(self, layer_idx: int, expert_ids: list[int]) -> None:
         """Copy expert weights to GPU shared buffers if not already present.
 
-        Two-path lookup:
+        Three-path lookup:
         1. Hot-layer cache: entire layer permanently on GPU → D2D copy
-        2. CPU→GPU copy: skips experts whose slot already holds this layer's data
-           (retained from a previous token), tracked via gpu_layer.
+        2. gpu_layer match: slot still holds this layer's data from prev token
+        3. Victim cache: data evicted by another layer → D2D restore
+        4. CPU→GPU copy (with victim-cache save of overwritten data)
         """
         gpu_w1_raw = self.gpu_w1.storage.data
         gpu_w2_raw = self.gpu_w2.storage.data
@@ -268,7 +399,7 @@ class ExpertCache:
                 self.gpu_layer[eid_i] = layer_idx
             return
 
-        # Path 2: CPU→GPU copy, skipping experts already resident from previous tokens
+        # Path 2-4: CPU-offloaded layers
         cpu_layer = self.cpu[layer_idx]
 
         for eid in expert_ids:
@@ -276,7 +407,33 @@ class ExpertCache:
             if self.gpu_layer[eid_i] == layer_idx:
                 self._hit_count += 1
                 continue
+
+            # Path 3: victim cache hit → D2D restore
+            if self._vc_slots > 0 and self._vc_get(
+                layer_idx, eid_i,
+                gpu_w1_raw[eid_i], gpu_w1_mx_raw[eid_i] if gpu_w1_mx_raw is not None else None,
+                self.gpu_b1[eid_i],
+                gpu_w2_raw[eid_i], gpu_w2_mx_raw[eid_i] if gpu_w2_mx_raw is not None else None,
+                self.gpu_b2[eid_i],
+            ):
+                self._hit_count += 1
+                self.gpu_layer[eid_i] = layer_idx
+                continue
+
             self._miss_count += 1
+            # Path 4: CPU→GPU copy. Save overwritten data to victim cache first.
+            prev_layer = self.gpu_layer[eid_i]
+            if self._vc_slots > 0 and prev_layer >= 0 and prev_layer != layer_idx:
+                self._vc_put(
+                    prev_layer, eid_i,
+                    gpu_w1_raw[eid_i],
+                    gpu_w1_mx_raw[eid_i] if gpu_w1_mx_raw is not None else None,
+                    self.gpu_b1[eid_i],
+                    gpu_w2_raw[eid_i],
+                    gpu_w2_mx_raw[eid_i] if gpu_w2_mx_raw is not None else None,
+                    self.gpu_b2[eid_i],
+                )
+
             cw = cpu_layer[eid_i]
             gpu_w1_raw[eid_i].copy_(cw["w1"])
             if gpu_w1_mx_raw is not None and cw.get("w1_mx") is not None:

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -18,7 +18,8 @@ if not cuda_capability_geq(9):
 else:
     from gpt_oss.triton.attention_tt_tma import attention
 
-from gpt_oss.triton.moe import quantize_mx4, moe, moe_decode
+from gpt_oss.triton.moe import quantize_mx4, moe, moe_decode, moe_decode_gate_routing, moe_decode_experts, moe_gate_routing, moe_experts
+from gpt_oss.triton.expert_cache import ExpertCache
 from gpt_oss.triton.triton_kernels import (
     out_residual_decode_forward,
     qkv_rope_cache_decode_forward,
@@ -578,12 +579,15 @@ class MLPBlock(torch.nn.Module):
         config: ModelConfig,
         layer_idx: int = 0,
         device: torch.device | None = None,
+        cpu_offload: bool = False,
     ):
         super().__init__()
         self.layer_idx = layer_idx
         self.num_experts = config.num_experts
         self.experts_per_token = config.experts_per_token
         self.swiglu_limit = config.swiglu_limit
+        self._cpu_offload = cpu_offload
+        self.expert_cache: ExpertCache | None = None
         self.norm = RMSNorm(config.hidden_size, device=device)
         self.gate = torch.nn.ParameterDict({
             "weight": torch.nn.Parameter(
@@ -607,50 +611,60 @@ class MLPBlock(torch.nn.Module):
             persistent=False,
         )
         self._gate_bias_fp32_version = self._maybe_tensor_version(self.gate["bias"])
-        self.mlp1_weight_tensor, self.mlp1_weight_mx = quantize_mx4(
-            torch.empty(
-                (
-                    config.num_experts,
-                    config.hidden_size,
-                    config.intermediate_size * 2,
+        if cpu_offload:
+            self.mlp1_weight_tensor = torch.empty(1, device=device)
+            self.mlp1_weight_mx = torch.empty(1, device=device)
+            self.mlp1_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            self.mlp1_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            self.mlp2_weight_tensor = torch.empty(1, device=device)
+            self.mlp2_weight_mx = torch.empty(1, device=device)
+            self.mlp2_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            self.mlp2_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+        else:
+            self.mlp1_weight_tensor, self.mlp1_weight_mx = quantize_mx4(
+                torch.empty(
+                    (
+                        config.num_experts,
+                        config.hidden_size,
+                        config.intermediate_size * 2,
+                    ),
+                    device=device,
+                    dtype=torch.bfloat16,
                 ),
-                device=device,
-                dtype=torch.bfloat16,
-            ),
-        )
-        self.mlp1_weight = torch.nn.Parameter(self.mlp1_weight_tensor.storage.data, requires_grad=False)
-        self.mlp1_bias = torch.nn.Parameter(
-            torch.empty(
-                (config.num_experts, config.intermediate_size * 2),
-                device=device,
-                dtype=torch.bfloat16,
             )
-        )
+            self.mlp1_weight = torch.nn.Parameter(self.mlp1_weight_tensor.storage.data, requires_grad=False)
+            self.mlp1_bias = torch.nn.Parameter(
+                torch.empty(
+                    (config.num_experts, config.intermediate_size * 2),
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+            )
+            self.mlp2_weight_tensor, self.mlp2_weight_mx = quantize_mx4(
+                torch.empty(
+                    (
+                        config.num_experts,
+                        config.intermediate_size,
+                        config.hidden_size,
+                    ),
+                    device=device,
+                    dtype=torch.bfloat16,
+                ),
+            )
+            self.mlp2_weight = torch.nn.Parameter(self.mlp2_weight_tensor.storage.data, requires_grad=False)
+            self.mlp2_bias = torch.nn.Parameter(
+                torch.empty(
+                    (config.num_experts, config.hidden_size),
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+            )
         self.register_buffer(
             "mlp1_bias_fp32_cache",
             self.mlp1_bias.detach().float().clone(),
             persistent=False,
         )
         self._mlp1_bias_fp32_version = self._maybe_tensor_version(self.mlp1_bias)
-        self.mlp2_weight_tensor, self.mlp2_weight_mx = quantize_mx4(
-            torch.empty(
-                (
-                    config.num_experts,
-                    config.intermediate_size,
-                    config.hidden_size,
-                ),
-                device=device,
-                dtype=torch.bfloat16,
-            ),
-        )
-        self.mlp2_weight = torch.nn.Parameter(self.mlp2_weight_tensor.storage.data, requires_grad=False)
-        self.mlp2_bias = torch.nn.Parameter(
-            torch.empty(
-                (config.num_experts, config.hidden_size),
-                device=device,
-                dtype=torch.bfloat16,
-            )
-        )
         self.register_buffer(
             "mlp2_bias_fp32_cache",
             self.mlp2_bias.detach().float().clone(),
@@ -739,8 +753,6 @@ class MLPBlock(torch.nn.Module):
         batch_size, n_ctx, dim = x.shape
         t = self.norm(x)
         gate_bias = self._get_gate_bias_fp32()
-        mlp1_bias = self._get_mlp1_bias_fp32()
-        mlp2_bias = self._get_mlp2_bias_fp32()
 
         t = t.view(batch_size * n_ctx, dim)
         if (
@@ -749,36 +761,80 @@ class MLPBlock(torch.nn.Module):
             and x.dtype == torch.bfloat16
             and self.gate["weight"].dtype == torch.bfloat16
         ):
-            t = moe_decode(
-                t,
-                self.gate["weight"],
-                self.mlp1_weight_tensor, self.mlp1_weight_mx,
-                self.mlp2_weight_tensor, self.mlp2_weight_mx,
-                gate_bias,
-                mlp1_bias,
-                mlp2_bias,
-                experts_per_token=self.experts_per_token,
-                num_experts=self.num_experts,
-                swiglu_limit=self.swiglu_limit,
-            )
+            if self._cpu_offload and self.expert_cache is not None:
+                t = self._forward_decode_offload(t, gate_bias)
+            else:
+                mlp1_bias = self._get_mlp1_bias_fp32()
+                mlp2_bias = self._get_mlp2_bias_fp32()
+                t = moe_decode(
+                    t,
+                    self.gate["weight"],
+                    self.mlp1_weight_tensor, self.mlp1_weight_mx,
+                    self.mlp2_weight_tensor, self.mlp2_weight_mx,
+                    gate_bias,
+                    mlp1_bias,
+                    mlp2_bias,
+                    experts_per_token=self.experts_per_token,
+                    num_experts=self.num_experts,
+                    swiglu_limit=self.swiglu_limit,
+                )
         else:
-            t = moe(
-                t,
-                self.gate["weight"],
-                self.mlp1_weight_tensor, self.mlp1_weight_mx,
-                self.mlp2_weight_tensor, self.mlp2_weight_mx,
-                gate_bias,
-                mlp1_bias,
-                mlp2_bias,
-                experts_per_token=self.experts_per_token,
-                num_experts=self.num_experts,
-                swiglu_limit=self.swiglu_limit,
-            )
+            if self._cpu_offload and self.expert_cache is not None:
+                rdata, gather_indx, scatter_indx = moe_gate_routing(
+                    t, self.gate["weight"], gate_bias,
+                    experts_per_token=self.experts_per_token,
+                )
+                if rdata is not None:
+                    expert_ids = torch.where(rdata.expt_hist > 0)[0]
+                    self.expert_cache.ensure_experts(self.layer_idx, expert_ids.tolist())
+                    t = moe_experts(
+                        t,
+                        self.expert_cache.gpu_w1, self.expert_cache.gpu_w1_mx,
+                        self.expert_cache.gpu_w2, self.expert_cache.gpu_w2_mx,
+                        self.expert_cache.gpu_b1,
+                        self.expert_cache.gpu_b2,
+                        rdata, gather_indx, scatter_indx,
+                        swiglu_limit=self.swiglu_limit,
+                    )
+            else:
+                mlp1_bias = self._get_mlp1_bias_fp32()
+                mlp2_bias = self._get_mlp2_bias_fp32()
+                t = moe(
+                    t,
+                    self.gate["weight"],
+                    self.mlp1_weight_tensor, self.mlp1_weight_mx,
+                    self.mlp2_weight_tensor, self.mlp2_weight_mx,
+                    gate_bias,
+                    mlp1_bias,
+                    mlp2_bias,
+                    experts_per_token=self.experts_per_token,
+                    num_experts=self.num_experts,
+                    swiglu_limit=self.swiglu_limit,
+                )
         t = t.view(batch_size, n_ctx, dim)
 
         x.add_(t)
         return x
 
+    def _forward_decode_offload(self, t: torch.Tensor, gate_bias: torch.Tensor) -> torch.Tensor:
+        cache = self.expert_cache
+        rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
+            t, self.gate["weight"], gate_bias,
+            experts_per_token=self.experts_per_token,
+            num_experts=self.num_experts,
+        )
+        if rdata is None:
+            return t
+        expert_ids = torch.where(rdata.expt_hist > 0)[0]
+        cache.ensure_experts(self.layer_idx, expert_ids.tolist())
+        return moe_decode_experts(
+            t,
+            cache.gpu_w1, cache.gpu_w1_mx,
+            cache.gpu_w2, cache.gpu_w2_mx,
+            cache.gpu_b1, cache.gpu_b2,
+            rdata, gather_indx, scatter_indx,
+            swiglu_limit=self.swiglu_limit,
+        )
 
 class TransformerBlock(torch.nn.Module):
     def __init__(
@@ -786,11 +842,12 @@ class TransformerBlock(torch.nn.Module):
         config: ModelConfig,
         layer_idx: int,
         device: torch.device | None = None,
+        cpu_offload: bool = False,
     ):
         super().__init__()
         self.layer_idx = layer_idx
         self.attn = AttentionBlock(config, layer_idx, device)
-        self.mlp = MLPBlock(config, layer_idx, device)
+        self.mlp = MLPBlock(config, layer_idx, device, cpu_offload=cpu_offload)
 
     def forward(self, x: torch.Tensor, cache: Cache | None = None) -> torch.Tensor:
         x = self.attn(x, cache=cache)
@@ -803,6 +860,7 @@ class Transformer(torch.nn.Module):
         self,
         config: ModelConfig,
         device: torch.device | None = None,
+        cpu_offload: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -811,7 +869,7 @@ class Transformer(torch.nn.Module):
         )
         self.block = torch.nn.ModuleList(
             [
-                TransformerBlock(config, layer_idx, device)
+                TransformerBlock(config, layer_idx, device, cpu_offload=cpu_offload)
                 for layer_idx in range(config.num_hidden_layers)
             ]
         )
@@ -842,7 +900,10 @@ class Transformer(torch.nn.Module):
 
     @staticmethod
     def from_checkpoint(
-        path: str, config: ModelConfig | None = None, device: str | torch.device = "cuda",
+        path: str,
+        config: ModelConfig | None = None,
+        device: str | torch.device = "cuda",
+        cpu_offload: bool = False,
     ) -> "Transformer":
         if not isinstance(device, torch.device):
             device = torch.device(device)
@@ -853,12 +914,20 @@ class Transformer(torch.nn.Module):
                 json_config = json.load(f)
                 config = ModelConfig(**json_config)
 
-        model = Transformer(config=config, device=device)
+        model = Transformer(config=config, device=device, cpu_offload=cpu_offload)
         model.eval()
 
         checkpoint = Checkpoint(path, device)
 
-        for name, param in model.named_parameters():
+        if cpu_offload:
+            model._load_with_cpu_offload(checkpoint, config)
+        else:
+            model._load_gpu_only(checkpoint)
+
+        return model
+
+    def _load_gpu_only(self, checkpoint: Checkpoint) -> None:
+        for name, param in self.named_parameters():
             torch.cuda.empty_cache()
             loaded_tensor = checkpoint.get(name)
 
@@ -866,7 +935,7 @@ class Transformer(torch.nn.Module):
                 if "weight" in name:
                     loaded_tensor, scales = quantize_mx4(loaded_tensor.mT.contiguous())
                     _, block_index, _, _ = name.split(".")
-                    model.block[int(block_index)].mlp.mlp1_weight_mx = scales
+                    self.block[int(block_index)].mlp.mlp1_weight_mx = scales
                     with torch.no_grad():
                         param.copy_(loaded_tensor.storage.data)
                 else:
@@ -876,7 +945,7 @@ class Transformer(torch.nn.Module):
             elif "mlp2_weight" in name:
                 loaded_tensor, scales = quantize_mx4(loaded_tensor.mT.contiguous())
                 _, block_index, _, _ = name.split(".")
-                model.block[int(block_index)].mlp.mlp2_weight_mx = scales
+                self.block[int(block_index)].mlp.mlp2_weight_mx = scales
                 with torch.no_grad():
                     param.copy_(loaded_tensor.storage.data)
 
@@ -889,29 +958,168 @@ class Transformer(torch.nn.Module):
                 with torch.no_grad():
                     param.copy_(loaded_tensor)
 
-        for block in model.block:
+        for block in self.block:
             block.mlp.refresh_fp32_bias_caches()
 
-        # NOTE: Required to avoid OOM errors
         torch.cuda.empty_cache()
-        return model
+
+    def _load_with_cpu_offload(self, checkpoint: Checkpoint, config: ModelConfig) -> None:
+        device = torch.device("cuda")
+        cache = ExpertCache(
+            num_experts=config.num_experts,
+            experts_per_token=config.experts_per_token,
+            device=device,
+        )
+
+        # Phase 1: load non-MLP params normally (small, stay on GPU)
+        for name, param in self.named_parameters():
+            if "mlp1" in name or "mlp2" in name:
+                continue
+            torch.cuda.empty_cache()
+            loaded_tensor = checkpoint.get(name)
+            if "gate" in name and loaded_tensor.ndim == 2:
+                loaded_tensor = loaded_tensor.mT.contiguous()
+            with torch.no_grad():
+                param.copy_(loaded_tensor)
+            del loaded_tensor
+
+        _after_p1 = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
+        print(f"GPU after Phase 1: {_after_p1/1e9:.2f} GB")
+
+        # Offload large non-MLP tensors to CPU to free GPU memory for quantization
+        # Embedding + UnEmbedding (~2.32 GB) + 36 layers attention QKV+OUT (~1.9 GB)
+        _cpu_offload_tensors: dict[str, torch.Tensor] = {}
+
+        def _move_to_cpu(model, attr_path):
+            obj = model
+            for part in attr_path.split(".")[:-1]:
+                obj = getattr(obj, part)
+            attr = attr_path.split(".")[-1]
+            param = getattr(obj, attr)
+            cpu_copy = param.data.cpu()
+            _cpu_offload_tensors[attr_path] = cpu_copy
+            param.data = torch.empty(1, device=device, dtype=param.dtype)
+
+        _move_to_cpu(self, "embedding.weight")
+        _move_to_cpu(self, "unembedding.weight")
+        for i in range(config.num_hidden_layers):
+            _move_to_cpu(self, f"block.{i}.attn.qkv.weight")
+            _move_to_cpu(self, f"block.{i}.attn.qkv.bias")
+            _move_to_cpu(self, f"block.{i}.attn.out.weight")
+            _move_to_cpu(self, f"block.{i}.attn.out.bias")
+        torch.cuda.empty_cache()
+
+        _after_offload = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
+        print(f"GPU after offload: {_after_offload/1e9:.2f} GB")
+
+        # Phase 2: load MLP expert weights layer-by-layer
+        for block_idx, block in enumerate(self.block):
+            mlp = block.mlp
+
+            # mlp1_weight
+            loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp1_weight")
+            torch.cuda.empty_cache()
+            loaded_t = loaded.mT.contiguous()
+            del loaded
+            w1, w1_mx = quantize_mx4(loaded_t)
+            del loaded_t
+            mlp.mlp1_weight_tensor = w1
+            mlp.mlp1_weight_mx = w1_mx
+            mlp.mlp1_weight = torch.nn.Parameter(w1.storage.data, requires_grad=False)
+
+            # mlp1_bias
+            loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp1_bias")
+            mlp.mlp1_bias = torch.nn.Parameter(loaded, requires_grad=False)
+            del loaded
+
+            # mlp2_weight
+            loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp2_weight")
+            torch.cuda.empty_cache()
+            loaded_t = loaded.mT.contiguous()
+            del loaded
+            w2, w2_mx = quantize_mx4(loaded_t)
+            del loaded_t
+            mlp.mlp2_weight_tensor = w2
+            mlp.mlp2_weight_mx = w2_mx
+            mlp.mlp2_weight = torch.nn.Parameter(w2.storage.data, requires_grad=False)
+
+            # mlp2_bias
+            loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp2_bias")
+            mlp.mlp2_bias = torch.nn.Parameter(loaded, requires_grad=False)
+            del loaded
+
+            mlp.refresh_fp32_bias_caches()
+
+            cache.register_layer(
+                block_idx,
+                w1, w1_mx, mlp.mlp1_bias,
+                w2, w2_mx, mlp.mlp2_bias,
+            )
+            mlp._cpu_offload = True
+            mlp.expert_cache = cache
+
+            # Free GPU expert tensors for this layer
+            mlp.mlp1_weight_tensor = torch.empty(1, device=device)
+            mlp.mlp1_weight_mx = torch.empty(1, device=device)
+            mlp.mlp2_weight_tensor = torch.empty(1, device=device)
+            mlp.mlp2_weight_mx = torch.empty(1, device=device)
+            mlp.mlp1_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            mlp.mlp1_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            mlp.mlp2_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+
+            torch.cuda.empty_cache()
+
+        # Restore offloaded tensors to GPU
+        def _restore_to_gpu(model, attr_path):
+            obj = model
+            for part in attr_path.split(".")[:-1]:
+                obj = getattr(obj, part)
+            attr = attr_path.split(".")[-1]
+            cpu_copy = _cpu_offload_tensors[attr_path]
+            getattr(obj, attr).data = cpu_copy.to(device)
+
+        for attr_path in _cpu_offload_tensors:
+            _restore_to_gpu(self, attr_path)
+        _cpu_offload_tensors.clear()
+        torch.cuda.empty_cache()
+
+        _final = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
+        print(f"GPU after Phase 2 + restore: {_final/1e9:.2f} GB")
 
 
 class TokenGenerator:
     @torch.inference_mode()
-    def __init__(self, checkpoint: str, context: int, device: torch.device):
+    def __init__(self, checkpoint: str, context: int, device: torch.device, cpu_offload: bool | None = None):
         self.device = device
-        self.use_cuda_graph = os.getenv("CUDA_GRAPH", "1").strip().lower() not in {"0", "false", "no", "off"}
+        if cpu_offload is None:
+            cpu_offload_env = os.getenv("CPU_OFFLOAD", "0").strip().lower()
+            cpu_offload = cpu_offload_env not in {"0", "false", "no", "off", ""}
+        self.cpu_offload = cpu_offload
+        self.use_cuda_graph = (
+            os.getenv("CUDA_GRAPH", "1").strip().lower() not in {"0", "false", "no", "off"}
+        )
+        if self.use_cuda_graph and self.cpu_offload:
+            print("CPU offload is incompatible with CUDA Graph; disabling CUDA Graph", flush=True)
+            self.use_cuda_graph = False
         print(termcolor.colored("Loading model checkpoint...", "yellow"), flush=True)
-        self.model = Transformer.from_checkpoint(checkpoint, device=self.device)
+        if self.cpu_offload:
+            print(termcolor.colored("CPU_OFFLOAD enabled: MoE expert weights on CPU, attention on GPU", "yellow"), flush=True)
+        self.model = Transformer.from_checkpoint(
+            checkpoint, device=self.device, cpu_offload=self.cpu_offload,
+        )
         self.caches = [Cache(1, context, self.model.config.num_key_value_heads, device=self.device) for _ in range(len(self.model.block))]
         self.enable_dense_cache_sliding = all(cache.can_slide() for cache in self.caches)
         repeat_stop_env = os.getenv("DENSE_REPEAT_PATTERN_STOP", "0").strip().lower()
         self.enable_repeat_pattern_stop = repeat_stop_env not in {"0", "false", "no", "off", ""}
         self._dense_slide_warned = False
         self.input_token = torch.zeros(1, dtype=torch.int32, device=self.device)
-        # warmup
-        self.model(self.input_token[None, :], caches=self.caches)
+        # warmup: trigger Triton JIT. With CPU offload only need one layer
+        # since all layers share the same kernel shapes.
+        if self.cpu_offload:
+            x = self.model.embedding(self.input_token[None, :])
+            x = self.model.block[0](x, cache=self.caches[0])
+        else:
+            self.model(self.input_token[None, :], caches=self.caches)
         self._sampling_graph = None
         self._greedy_graph = None
         self._greedy_token: torch.Tensor | None = None

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -863,6 +863,13 @@ class MLPBlock(torch.nn.Module):
         cache.route_to_matmul_proxies()
         cache._g_x.copy_(t)
         cache.decode_graph.replay()
+
+        if self.layer_idx == 0 and cache._miss_count + cache._hit_count > 0:
+            hr = cache.hit_rate()
+            print(f"[gpu_layer reuse] hit={cache._hit_count} miss={cache._miss_count} "
+                  f"rate={hr:.1%}", flush=True)
+            cache.reset_hit_rate()
+
         return cache._g_out
 
 class TransformerBlock(torch.nn.Module):

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -865,9 +865,12 @@ class MLPBlock(torch.nn.Module):
         cache.decode_graph.replay()
 
         if self.layer_idx == 0 and cache._miss_count + cache._hit_count > 0:
-            hr = cache.hit_rate()
-            print(f"[gpu_layer reuse] hit={cache._hit_count} miss={cache._miss_count} "
-                  f"rate={hr:.1%}", flush=True)
+            if os.getenv("PRINT_HIT_RATE", "0").strip().lower() not in {"0", "false", "no", "off"}:
+                if getattr(cache, '_print_ctr', 0) % 10 == 0:
+                    hr = cache.hit_rate()
+                    print(f"[gpu_layer reuse] hit={cache._hit_count} miss={cache._miss_count} "
+                          f"rate={hr:.1%}")
+            cache._print_ctr = getattr(cache, '_print_ctr', 0) + 1
             cache.reset_hit_rate()
 
         return cache._g_out
@@ -1127,6 +1130,11 @@ class Transformer(torch.nn.Module):
 
         _final = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
         print(f"GPU after Phase 2 + restore: {_final/1e9:.2f} GB")
+
+        # Allocate victim cache from remaining free VRAM
+        _vc_env = os.getenv("VICTIM_CACHE", "1").strip().lower()
+        if _vc_env not in {"0", "false", "no", "off"}:
+            cache.init_victim_cache(max_slots=120)
 
 
 class TokenGenerator:

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -19,7 +19,6 @@ else:
     from gpt_oss.triton.attention_tt_tma import attention
 
 from gpt_oss.triton.moe import quantize_mx4, moe, moe_decode, moe_decode_gate_routing, moe_decode_experts, moe_gate_routing, moe_experts
-from triton_kernels.numerics_details.mxfp import downcast_to_mxfp_torch
 from gpt_oss.triton.expert_cache import ExpertCache
 from gpt_oss.triton.triton_kernels import (
     out_residual_decode_forward,
@@ -820,20 +819,6 @@ class MLPBlock(torch.nn.Module):
     def _forward_decode_offload(self, t: torch.Tensor, gate_bias: torch.Tensor) -> torch.Tensor:
         cache = self.expert_cache
 
-        # ---- CPU expert path ----
-        if os.getenv("CPU_EXPERT", "0").strip().lower() not in {"0", "false", "no", "off", ""}:
-            logits = torch.matmul(t, self.gate["weight"]).float()
-            if gate_bias is not None:
-                logits = logits + gate_bias
-            topk_weights, topk_indices = torch.topk(logits, self.experts_per_token)
-            topk_weights = torch.softmax(topk_weights, dim=-1)
-            return cache.cpu_expert_forward(
-                self.layer_idx, t,
-                topk_indices[0].tolist(),  # [experts_per_token]
-                topk_weights[0],           # [experts_per_token]
-                swiglu_limit=self.swiglu_limit,
-            )
-
         if cache.route_graph is None:
             # First call: run routing + matmul eagerly, then capture both graphs
             rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
@@ -1008,7 +993,6 @@ class Transformer(torch.nn.Module):
         torch.cuda.empty_cache()
 
     def _load_with_cpu_offload(self, checkpoint: Checkpoint, config: ModelConfig) -> None:
-        _cpu_expert = os.getenv("CPU_EXPERT", "0").strip().lower() not in {"0", "false", "no", "off", ""}
         device = torch.device("cuda")
         cache = ExpertCache(
             num_experts=config.num_experts,
@@ -1067,18 +1051,13 @@ class Transformer(torch.nn.Module):
             loaded_t = loaded.mT.contiguous()
             del loaded
             w1, w1_mx = quantize_mx4(loaded_t)
-            # Simple (non-swizzled) FP4 for CPU-side: move to CPU first to free GPU mem
-            loaded_cpu = loaded_t.cpu()
             del loaded_t
-            w1_fp4, w1_fp4_scale = downcast_to_mxfp_torch(loaded_cpu, torch.uint8, axis=1)
-            del loaded_cpu
             mlp.mlp1_weight_tensor = w1
             mlp.mlp1_weight_mx = w1_mx
             mlp.mlp1_weight = torch.nn.Parameter(w1.storage.data, requires_grad=False)
 
             # mlp1_bias
             loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp1_bias")
-            b1 = loaded.detach()
             mlp.mlp1_bias = torch.nn.Parameter(loaded, requires_grad=False)
             del loaded
 
@@ -1088,17 +1067,13 @@ class Transformer(torch.nn.Module):
             loaded_t = loaded.mT.contiguous()
             del loaded
             w2, w2_mx = quantize_mx4(loaded_t)
-            loaded_cpu = loaded_t.cpu()
             del loaded_t
-            w2_fp4, w2_fp4_scale = downcast_to_mxfp_torch(loaded_cpu, torch.uint8, axis=1)
-            del loaded_cpu
             mlp.mlp2_weight_tensor = w2
             mlp.mlp2_weight_mx = w2_mx
             mlp.mlp2_weight = torch.nn.Parameter(w2.storage.data, requires_grad=False)
 
             # mlp2_bias
             loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp2_bias")
-            b2 = loaded.detach()
             mlp.mlp2_bias = torch.nn.Parameter(loaded, requires_grad=False)
             del loaded
 
@@ -1108,13 +1083,7 @@ class Transformer(torch.nn.Module):
                 block_idx,
                 w1, w1_mx, mlp.mlp1_bias,
                 w2, w2_mx, mlp.mlp2_bias,
-                store_cpu=not _cpu_expert,
             )
-            cache.register_cpu_fp4(
-                block_idx, w1_fp4, w1_fp4_scale, b1,
-                w2_fp4, w2_fp4_scale, b2,
-            )
-            del w1_fp4, w1_fp4_scale, b1, w2_fp4, w2_fp4_scale, b2
             mlp._cpu_offload = True
             mlp.expert_cache = cache
 
@@ -1145,8 +1114,6 @@ class Transformer(torch.nn.Module):
 
         _final = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
         print(f"GPU after Phase 2 + restore: {_final/1e9:.2f} GB")
-
-        # CPU offload: expert weights stay on CPU, copied to GPU on-demand during decode
 
 
 class TokenGenerator:

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -19,6 +19,7 @@ else:
     from gpt_oss.triton.attention_tt_tma import attention
 
 from gpt_oss.triton.moe import quantize_mx4, moe, moe_decode, moe_decode_gate_routing, moe_decode_experts, moe_gate_routing, moe_experts
+from triton_kernels.numerics_details.mxfp import downcast_to_mxfp_torch
 from gpt_oss.triton.expert_cache import ExpertCache
 from gpt_oss.triton.triton_kernels import (
     out_residual_decode_forward,
@@ -819,6 +820,20 @@ class MLPBlock(torch.nn.Module):
     def _forward_decode_offload(self, t: torch.Tensor, gate_bias: torch.Tensor) -> torch.Tensor:
         cache = self.expert_cache
 
+        # ---- CPU expert path ----
+        if os.getenv("CPU_EXPERT", "0").strip().lower() not in {"0", "false", "no", "off", ""}:
+            logits = torch.matmul(t, self.gate["weight"]).float()
+            if gate_bias is not None:
+                logits = logits + gate_bias
+            topk_weights, topk_indices = torch.topk(logits, self.experts_per_token)
+            topk_weights = torch.softmax(topk_weights, dim=-1)
+            return cache.cpu_expert_forward(
+                self.layer_idx, t,
+                topk_indices[0].tolist(),  # [experts_per_token]
+                topk_weights[0],           # [experts_per_token]
+                swiglu_limit=self.swiglu_limit,
+            )
+
         if cache.route_graph is None:
             # First call: run routing + matmul eagerly, then capture both graphs
             rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
@@ -993,6 +1008,7 @@ class Transformer(torch.nn.Module):
         torch.cuda.empty_cache()
 
     def _load_with_cpu_offload(self, checkpoint: Checkpoint, config: ModelConfig) -> None:
+        _cpu_expert = os.getenv("CPU_EXPERT", "0").strip().lower() not in {"0", "false", "no", "off", ""}
         device = torch.device("cuda")
         cache = ExpertCache(
             num_experts=config.num_experts,
@@ -1051,13 +1067,18 @@ class Transformer(torch.nn.Module):
             loaded_t = loaded.mT.contiguous()
             del loaded
             w1, w1_mx = quantize_mx4(loaded_t)
+            # Simple (non-swizzled) FP4 for CPU-side: move to CPU first to free GPU mem
+            loaded_cpu = loaded_t.cpu()
             del loaded_t
+            w1_fp4, w1_fp4_scale = downcast_to_mxfp_torch(loaded_cpu, torch.uint8, axis=1)
+            del loaded_cpu
             mlp.mlp1_weight_tensor = w1
             mlp.mlp1_weight_mx = w1_mx
             mlp.mlp1_weight = torch.nn.Parameter(w1.storage.data, requires_grad=False)
 
             # mlp1_bias
             loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp1_bias")
+            b1 = loaded.detach()
             mlp.mlp1_bias = torch.nn.Parameter(loaded, requires_grad=False)
             del loaded
 
@@ -1067,13 +1088,17 @@ class Transformer(torch.nn.Module):
             loaded_t = loaded.mT.contiguous()
             del loaded
             w2, w2_mx = quantize_mx4(loaded_t)
+            loaded_cpu = loaded_t.cpu()
             del loaded_t
+            w2_fp4, w2_fp4_scale = downcast_to_mxfp_torch(loaded_cpu, torch.uint8, axis=1)
+            del loaded_cpu
             mlp.mlp2_weight_tensor = w2
             mlp.mlp2_weight_mx = w2_mx
             mlp.mlp2_weight = torch.nn.Parameter(w2.storage.data, requires_grad=False)
 
             # mlp2_bias
             loaded = checkpoint.get(f"block.{block_idx}.mlp.mlp2_bias")
+            b2 = loaded.detach()
             mlp.mlp2_bias = torch.nn.Parameter(loaded, requires_grad=False)
             del loaded
 
@@ -1083,7 +1108,13 @@ class Transformer(torch.nn.Module):
                 block_idx,
                 w1, w1_mx, mlp.mlp1_bias,
                 w2, w2_mx, mlp.mlp2_bias,
+                store_cpu=not _cpu_expert,
             )
+            cache.register_cpu_fp4(
+                block_idx, w1_fp4, w1_fp4_scale, b1,
+                w2_fp4, w2_fp4_scale, b2,
+            )
+            del w1_fp4, w1_fp4_scale, b1, w2_fp4, w2_fp4_scale, b2
             mlp._cpu_offload = True
             mlp.expert_cache = cache
 

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -1000,6 +1000,9 @@ class Transformer(torch.nn.Module):
             device=device,
         )
 
+        # Determine how many hot layers can be cached on GPU
+        _n_cache = cache.init_layer_cache(max_layers=10)
+
         # Phase 1: load non-MLP params normally (small, stay on GPU)
         for name, param in self.named_parameters():
             if "mlp1" in name or "mlp2" in name:
@@ -1079,22 +1082,25 @@ class Transformer(torch.nn.Module):
 
             mlp.refresh_fp32_bias_caches()
 
+            _hot = block_idx < _n_cache
             cache.register_layer(
                 block_idx,
                 w1, w1_mx, mlp.mlp1_bias,
                 w2, w2_mx, mlp.mlp2_bias,
+                cache_on_gpu=_hot,
             )
             mlp._cpu_offload = True
             mlp.expert_cache = cache
 
-            # Free GPU expert tensors for this layer
-            mlp.mlp1_weight_tensor = torch.empty(1, device=device)
-            mlp.mlp1_weight_mx = torch.empty(1, device=device)
-            mlp.mlp2_weight_tensor = torch.empty(1, device=device)
-            mlp.mlp2_weight_mx = torch.empty(1, device=device)
-            mlp.mlp1_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
-            mlp.mlp1_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
-            mlp.mlp2_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+            if not _hot:
+                # Free GPU expert tensors for this layer (cold layers)
+                mlp.mlp1_weight_tensor = torch.empty(1, device=device)
+                mlp.mlp1_weight_mx = torch.empty(1, device=device)
+                mlp.mlp2_weight_tensor = torch.empty(1, device=device)
+                mlp.mlp2_weight_mx = torch.empty(1, device=device)
+                mlp.mlp1_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+                mlp.mlp1_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+                mlp.mlp2_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
 
             torch.cuda.empty_cache()
 

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -818,23 +818,52 @@ class MLPBlock(torch.nn.Module):
 
     def _forward_decode_offload(self, t: torch.Tensor, gate_bias: torch.Tensor) -> torch.Tensor:
         cache = self.expert_cache
-        rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
-            t, self.gate["weight"], gate_bias,
-            experts_per_token=self.experts_per_token,
-            num_experts=self.num_experts,
-        )
-        if rdata is None:
-            return t
-        expert_ids = torch.where(rdata.expt_hist > 0)[0]
+
+        if cache.route_graph is None:
+            # First call: run routing + matmul eagerly, then capture both graphs
+            rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
+                t, self.gate["weight"], gate_bias,
+                experts_per_token=self.experts_per_token,
+                num_experts=self.num_experts,
+            )
+            if rdata is None:
+                return t
+            expert_ids = torch.where(rdata.expt_hist > 0)[0]
+            cache.ensure_experts(self.layer_idx, expert_ids.tolist())
+
+            t_out = moe_decode_experts(
+                t,
+                cache.gpu_w1, cache.gpu_w1_mx,
+                cache.gpu_w2, cache.gpu_w2_mx,
+                cache.gpu_b1, cache.gpu_b2,
+                rdata, gather_indx, scatter_indx,
+                swiglu_limit=self.swiglu_limit,
+            )
+
+            cache.init_route_graph(
+                t, self.gate["weight"], gate_bias,
+                experts_per_token=self.experts_per_token,
+                num_experts=self.num_experts,
+            )
+            cache.init_decode_graph(rdata, gather_indx, scatter_indx, swiglu_limit=self.swiglu_limit)
+            cache._g_x.copy_(t)
+            cache._g_out.copy_(t_out)
+            return t_out
+
+        # Replay path: route graph → copy experts → matmul graph
+        cache._gr_t.copy_(t)
+        cache._gr_wg.copy_(self.gate["weight"])
+        if cache._gr_bg is not None and gate_bias is not None:
+            cache._gr_bg.copy_(gate_bias)
+
+        cache.route_graph.replay()
+        expert_ids = torch.where(cache._gr_rdata.expt_hist > 0)[0]
         cache.ensure_experts(self.layer_idx, expert_ids.tolist())
-        return moe_decode_experts(
-            t,
-            cache.gpu_w1, cache.gpu_w1_mx,
-            cache.gpu_w2, cache.gpu_w2_mx,
-            cache.gpu_b1, cache.gpu_b2,
-            rdata, gather_indx, scatter_indx,
-            swiglu_limit=self.swiglu_limit,
-        )
+
+        cache.route_to_matmul_proxies()
+        cache._g_x.copy_(t)
+        cache.decode_graph.replay()
+        return cache._g_out
 
 class TransformerBlock(torch.nn.Module):
     def __init__(
@@ -1095,12 +1124,11 @@ class TokenGenerator:
             cpu_offload_env = os.getenv("CPU_OFFLOAD", "0").strip().lower()
             cpu_offload = cpu_offload_env not in {"0", "false", "no", "off", ""}
         self.cpu_offload = cpu_offload
-        self.use_cuda_graph = (
+        self.use_global_cuda_graph = (
             os.getenv("CUDA_GRAPH", "1").strip().lower() not in {"0", "false", "no", "off"}
         )
-        if self.use_cuda_graph and self.cpu_offload:
-            print("CPU offload is incompatible with CUDA Graph; disabling CUDA Graph", flush=True)
-            self.use_cuda_graph = False
+        if self.use_global_cuda_graph and self.cpu_offload:
+            self.use_global_cuda_graph = False  # global graph incompatible; per-layer graphs used instead
         print(termcolor.colored("Loading model checkpoint...", "yellow"), flush=True)
         if self.cpu_offload:
             print(termcolor.colored("CPU_OFFLOAD enabled: MoE expert weights on CPU, attention on GPU", "yellow"), flush=True)
@@ -1123,7 +1151,7 @@ class TokenGenerator:
         self._sampling_graph = None
         self._greedy_graph = None
         self._greedy_token: torch.Tensor | None = None
-        if self.use_cuda_graph:
+        if self.use_global_cuda_graph:
             self._sampling_graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(self._sampling_graph):
                 self.logits = self.model(self.input_token[None, :], caches=self.caches)[0]
@@ -1132,7 +1160,8 @@ class TokenGenerator:
                 self._greedy_token = self.model.forward_greedy(self.input_token[None, :], caches=self.caches)
         else:
             self.logits = None
-            print(termcolor.colored("CUDA Graph disabled, using eager mode", "yellow"), flush=True)
+            if not self.cpu_offload:
+                print(termcolor.colored("CUDA Graph disabled, using eager mode", "yellow"), flush=True)
         self._sampling_probs = torch.empty(self.model.config.vocab_size, device=self.device, dtype=torch.bfloat16)
         self.last_generation_stats = None
         if self.enable_dense_cache_sliding:
@@ -1265,9 +1294,9 @@ class TokenGenerator:
                     if not can_continue:
                         return
                     self.input_token[0] = predicted_token
-                    if self.use_cuda_graph and self._greedy_graph is not None and temperature == 0.0:
+                    if self.use_global_cuda_graph and self._greedy_graph is not None and temperature == 0.0:
                         self._greedy_graph.replay()
-                    elif self.use_cuda_graph:
+                    elif self.use_global_cuda_graph:
                         self._sampling_graph.replay()
                     else:
                         self.logits = self.model(self.input_token[None, :], caches=self.caches)[0]
@@ -1292,13 +1321,13 @@ class TokenGenerator:
                 break
             self.input_token[0] = predicted_token
             if use_fused_greedy:
-                if self.use_cuda_graph:
+                if self.use_global_cuda_graph:
                     self._greedy_graph.replay()
                     predicted_token = self._greedy_token.item()
                 else:
                     predicted_token = self.model.forward_greedy(self.input_token[None, :], caches=self.caches).item()
             else:
-                if self.use_cuda_graph:
+                if self.use_global_cuda_graph:
                     self._sampling_graph.replay()
                 else:
                     self.logits = self.model(self.input_token[None, :], caches=self.caches)[0]

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -1115,17 +1115,7 @@ class Transformer(torch.nn.Module):
         _final = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
         print(f"GPU after Phase 2 + restore: {_final/1e9:.2f} GB")
 
-        # Initialise hot-layer GPU cache using free VRAM
-        n_cache = cache.init_layer_cache(max_layers=10)
-        if n_cache > 0:
-            print(f"GPU layer cache: {n_cache} slots ({cache._cache_bytes_per_layer * n_cache / 1e9:.2f} GB)")
-            # Pre-cache the first N layers so the second decode token benefits
-            n_prefill = min(n_cache, len(self.block))
-            for lid in range(n_prefill):
-                cache.cache_layer(lid)
-            print(f"GPU layer cache: pre-filled {n_prefill} layers")
-        else:
-            print("GPU layer cache: insufficient free VRAM")
+        # CPU offload: expert weights stay on CPU, copied to GPU on-demand during decode
 
 
 class TokenGenerator:

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -1115,6 +1115,18 @@ class Transformer(torch.nn.Module):
         _final = torch.cuda.memory_stats().get('allocated_bytes.all.current', 0)
         print(f"GPU after Phase 2 + restore: {_final/1e9:.2f} GB")
 
+        # Initialise hot-layer GPU cache using free VRAM
+        n_cache = cache.init_layer_cache(max_layers=10)
+        if n_cache > 0:
+            print(f"GPU layer cache: {n_cache} slots ({cache._cache_bytes_per_layer * n_cache / 1e9:.2f} GB)")
+            # Pre-cache the first N layers so the second decode token benefits
+            n_prefill = min(n_cache, len(self.block))
+            for lid in range(n_prefill):
+                cache.cache_layer(lid)
+            print(f"GPU layer cache: pre-filled {n_prefill} layers")
+        else:
+            print("GPU layer cache: insufficient free VRAM")
+
 
 class TokenGenerator:
     @torch.inference_mode()

--- a/tritonllm/gpt_oss/triton/model.py
+++ b/tritonllm/gpt_oss/triton/model.py
@@ -1003,15 +1003,16 @@ class Transformer(torch.nn.Module):
         torch.cuda.empty_cache()
 
     def _load_with_cpu_offload(self, checkpoint: Checkpoint, config: ModelConfig) -> None:
-        device = torch.device("cuda")
+        device = self.embedding.weight.device
         cache = ExpertCache(
             num_experts=config.num_experts,
             experts_per_token=config.experts_per_token,
             device=device,
         )
 
-        # Determine how many hot layers can be cached on GPU
-        _n_cache = cache.init_layer_cache(max_layers=10)
+        # Hot-layer cache capacity is determined after the first layer is
+        # registered (register_layer computes _cache_bytes_per_layer).
+        _n_cache = 0
 
         # Phase 1: load non-MLP params normally (small, stay on GPU)
         for name, param in self.named_parameters():
@@ -1110,9 +1111,14 @@ class Transformer(torch.nn.Module):
                 mlp.mlp2_weight_mx = torch.empty(1, device=device)
                 mlp.mlp1_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
                 mlp.mlp1_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
+                mlp.mlp2_weight = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
                 mlp.mlp2_bias = torch.nn.Parameter(torch.empty(1, device=device), requires_grad=False)
 
             torch.cuda.empty_cache()
+
+            # After the first layer registers, we know per-layer byte size
+            if block_idx == 0:
+                _n_cache = cache.init_layer_cache(max_layers=10)
 
         # Restore offloaded tensors to GPU
         def _restore_to_gpu(model, attr_path):

--- a/tritonllm/gpt_oss/triton/moe.py
+++ b/tritonllm/gpt_oss/triton/moe.py
@@ -1,4 +1,3 @@
-import os
 import torch
 from torch.profiler import record_function
 
@@ -136,12 +135,10 @@ def moe_decode_experts(
     pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
     pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
 
-    _block_k = int(os.environ["MOE_BLOCK_K"]) if os.environ.get("MOE_BLOCK_K") else None
+    update_opt_flags_constraints({"block_k": 64})
 
     if fused_act:
         assert interleaved, "Fused activation requires interleaved weights"
-        if _block_k is not None:
-            update_opt_flags_constraints({"block_k": _block_k})
         with record_function("w1+swiglu_decode"):
             act = FusedActivation(
                 FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")),
@@ -154,15 +151,11 @@ def moe_decode_experts(
                 fused_activation=act,
             )
     else:
-        if _block_k is not None:
-            update_opt_flags_constraints({"block_k": _block_k})
         with record_function("w1_decode"):
             x = matmul_ogs(x, w1, b1, rdata, gather_indx=gather_indx, precision_config=pc1)
         with record_function("swiglu_decode"):
             x = swiglu(x, limit=swiglu_limit, interleaved=interleaved)
 
-    if _block_k is not None:
-        update_opt_flags_constraints({"block_k": _block_k})
     with record_function("w2_decode"):
         x = matmul_ogs(
             x, w2, b2, rdata,
@@ -170,8 +163,6 @@ def moe_decode_experts(
             precision_config=pc2,
             gammas=rdata.gate_scal,
         )
-    if _block_k is not None:
-        reset_opt_flags_constraints()
     return x
 
 

--- a/tritonllm/gpt_oss/triton/moe.py
+++ b/tritonllm/gpt_oss/triton/moe.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from torch.profiler import record_function
 
@@ -10,6 +11,7 @@ from triton_kernels.routing import routing
 from triton_kernels.tensor import convert_layout
 from triton_kernels.tensor_details.layout import StridedLayout, make_default_matmul_mxfp4_w_layout
 from triton_kernels.tensor import wrap_torch_tensor, FP4
+from triton_kernels.matmul_ogs_details.opt_flags import update_opt_flags_constraints, reset_opt_flags_constraints
 
 
 def quantize_mx4(w):
@@ -31,18 +33,43 @@ def swiglu(x, alpha: float = 1.702, limit: float = 7.0, interleaved: bool = True
     return out_glu * (x_linear + 1)
 
 
-def moe(x, wg, w1, w1_mx, w2, w2_mx, bg, b1, b2, experts_per_token=4, num_experts=128, swiglu_limit=7.0, fused_act=True, interleaved=True):
+def moe_gate_routing(
+    x: torch.Tensor,
+    wg: torch.Tensor,
+    bg: torch.Tensor | None,
+    experts_per_token: int = 4,
+    num_experts: int = 128,
+):
     if x.numel() == 0:
-        return x
-
-    pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
-    pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
-    pcg = PrecisionConfig(flex_ctx=FlexCtx(rhs_data=InFlexData()))
-
+        return None, None, None
     with record_function("wg"):
-        logits = matmul_ogs(x, wg, bg, precision_config=pcg)
+        logits = torch.matmul(x, wg).float()
+        if bg is not None:
+            logits = logits + bg
     with record_function("routing"):
         rdata, gather_indx, scatter_indx = routing(logits, experts_per_token, simulated_ep=1)
+    return rdata, gather_indx, scatter_indx
+
+
+def moe_experts(
+    x: torch.Tensor,
+    w1,
+    w1_mx,
+    w2,
+    w2_mx,
+    b1: torch.Tensor,
+    b2: torch.Tensor,
+    rdata,
+    gather_indx,
+    scatter_indx,
+    swiglu_limit: float = 7.0,
+    fused_act: bool = True,
+    interleaved: bool = True,
+):
+    if x.numel() == 0:
+        return x
+    pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
+    pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
 
     if fused_act:
         assert interleaved, "Fused activation requires interleaved weights"
@@ -57,6 +84,94 @@ def moe(x, wg, w1, w1_mx, w2, w2_mx, bg, b1, b2, experts_per_token=4, num_expert
 
     with record_function("w2"):
         x = matmul_ogs(x, w2, b2, rdata, scatter_indx=scatter_indx, precision_config=pc2, gammas=rdata.gate_scal)
+    return x
+
+
+def moe(x, wg, w1, w1_mx, w2, w2_mx, bg, b1, b2, experts_per_token=4, num_experts=128, swiglu_limit=7.0, fused_act=True, interleaved=True):
+    rdata, gather_indx, scatter_indx = moe_gate_routing(x, wg, bg, experts_per_token)
+    if rdata is None:
+        return x
+    return moe_experts(x, w1, w1_mx, w2, w2_mx, b1, b2, rdata, gather_indx, scatter_indx,
+                       swiglu_limit=swiglu_limit, fused_act=fused_act, interleaved=interleaved)
+
+
+def moe_decode_gate_routing(
+    x: torch.Tensor,
+    wg: torch.Tensor,
+    bg: torch.Tensor | None,
+    experts_per_token: int = 4,
+    num_experts: int = 128,
+):
+    if x.numel() == 0:
+        return None, None, None
+    with record_function("wg_decode"):
+        logits = torch.matmul(x, wg).float()
+        if bg is not None:
+            logits = logits + bg
+    with record_function("routing_decode"):
+        rdata, gather_indx, scatter_indx = routing(
+            logits, experts_per_token, simulated_ep=1
+        )
+    return rdata, gather_indx, scatter_indx
+
+
+def moe_decode_experts(
+    x: torch.Tensor,
+    w1,
+    w1_mx,
+    w2,
+    w2_mx,
+    b1: torch.Tensor,
+    b2: torch.Tensor,
+    rdata,
+    gather_indx,
+    scatter_indx,
+    swiglu_limit: float = 7.0,
+    fused_act: bool = True,
+    interleaved: bool = True,
+):
+    if x.numel() == 0:
+        return x
+
+    pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
+    pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
+
+    _block_k = int(os.environ["MOE_BLOCK_K"]) if os.environ.get("MOE_BLOCK_K") else None
+
+    if fused_act:
+        assert interleaved, "Fused activation requires interleaved weights"
+        if _block_k is not None:
+            update_opt_flags_constraints({"block_k": _block_k})
+        with record_function("w1+swiglu_decode"):
+            act = FusedActivation(
+                FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")),
+                (1.702, swiglu_limit), 2,
+            )
+            x = matmul_ogs(
+                x, w1, b1, rdata,
+                gather_indx=gather_indx,
+                precision_config=pc1,
+                fused_activation=act,
+            )
+    else:
+        if _block_k is not None:
+            update_opt_flags_constraints({"block_k": _block_k})
+        with record_function("w1_decode"):
+            x = matmul_ogs(x, w1, b1, rdata, gather_indx=gather_indx, precision_config=pc1)
+        with record_function("swiglu_decode"):
+            x = swiglu(x, limit=swiglu_limit, interleaved=interleaved)
+
+    if _block_k is not None:
+        update_opt_flags_constraints({"block_k": _block_k})
+    with record_function("w2_decode"):
+        x = matmul_ogs(
+            x, w2, b2, rdata,
+            scatter_indx=scatter_indx,
+            precision_config=pc2,
+            gammas=rdata.gate_scal,
+        )
+    if _block_k is not None:
+        reset_opt_flags_constraints()
     return x
 
 
@@ -76,30 +191,15 @@ def moe_decode(
     fused_act=True,
     interleaved=True,
 ):
-    if x.numel() == 0:
+    rdata, gather_indx, scatter_indx = moe_decode_gate_routing(
+        x, wg, bg, experts_per_token, num_experts,
+    )
+    if rdata is None:
         return x
-
-    pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
-    pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
-
-    with record_function("wg_decode"):
-        logits = torch.matmul(x, wg).float()
-        if bg is not None:
-            logits = logits + bg
-    with record_function("routing_decode"):
-        rdata, gather_indx, scatter_indx = routing(logits, experts_per_token, simulated_ep=1)
-
-    if fused_act:
-        assert interleaved, "Fused activation requires interleaved weights"
-        with record_function("w1+swiglu_decode"):
-            act = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")), (1.702, swiglu_limit), 2)
-            x = matmul_ogs(x, w1, b1, rdata, gather_indx=gather_indx, precision_config=pc1, fused_activation=act)
-    else:
-        with record_function("w1_decode"):
-            x = matmul_ogs(x, w1, b1, rdata, gather_indx=gather_indx, precision_config=pc1)
-        with record_function("swiglu_decode"):
-            x = swiglu(x, limit=swiglu_limit, interleaved=interleaved)
-
-    with record_function("w2_decode"):
-        x = matmul_ogs(x, w2, b2, rdata, scatter_indx=scatter_indx, precision_config=pc2, gammas=rdata.gate_scal)
-    return x
+    return moe_decode_experts(
+        x, w1, w1_mx, w2, w2_mx, b1, b2,
+        rdata, gather_indx, scatter_indx,
+        swiglu_limit=swiglu_limit,
+        fused_act=fused_act,
+        interleaved=interleaved,
+    )

--- a/tritonllm/gpt_oss/triton/moe.py
+++ b/tritonllm/gpt_oss/triton/moe.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from torch.profiler import record_function
 
@@ -135,10 +136,12 @@ def moe_decode_experts(
     pc1 = PrecisionConfig(weight_scale=w1_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
     pc2 = PrecisionConfig(weight_scale=w2_mx, flex_ctx=FlexCtx(rhs_data=InFlexData()))
 
-    update_opt_flags_constraints({"block_k": 64})
+    _block_k = int(os.environ["MOE_BLOCK_K"]) if os.environ.get("MOE_BLOCK_K") else None
 
     if fused_act:
         assert interleaved, "Fused activation requires interleaved weights"
+        if _block_k is not None:
+            update_opt_flags_constraints({"block_k": _block_k})
         with record_function("w1+swiglu_decode"):
             act = FusedActivation(
                 FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")),
@@ -151,11 +154,15 @@ def moe_decode_experts(
                 fused_activation=act,
             )
     else:
+        if _block_k is not None:
+            update_opt_flags_constraints({"block_k": _block_k})
         with record_function("w1_decode"):
             x = matmul_ogs(x, w1, b1, rdata, gather_indx=gather_indx, precision_config=pc1)
         with record_function("swiglu_decode"):
             x = swiglu(x, limit=swiglu_limit, interleaved=interleaved)
 
+    if _block_k is not None:
+        update_opt_flags_constraints({"block_k": _block_k})
     with record_function("w2_decode"):
         x = matmul_ogs(
             x, w2, b2, rdata,
@@ -163,6 +170,8 @@ def moe_decode_experts(
             precision_config=pc2,
             gammas=rdata.gate_scal,
         )
+    if _block_k is not None:
+        reset_opt_flags_constraints()
     return x
 
 

--- a/tritonllm/gpt_oss/triton/weights.py
+++ b/tritonllm/gpt_oss/triton/weights.py
@@ -71,7 +71,7 @@ class Checkpoint:
         scales_name: str,
         *,
         dtype: torch.dtype = torch.bfloat16,
-        rows_per_chunk: int = 32768 * 1024,
+        rows_per_chunk: int = 8192 * 1024,
     ) -> torch.Tensor:
         assert blocks_name in self.tensor_name_to_file, (
             f"Blocks tensor {blocks_name} not found in checkpoint."
@@ -103,9 +103,9 @@ class Checkpoint:
             blk = blocks[r0:r1]
             exp = scales[r0:r1]
 
-            # nibble indices -> int64
-            idx_lo = (blk & 0x0F).to(torch.long)
-            idx_hi = (blk >> 4).to(torch.long)
+            # nibble indices -> int32 (saves 50% memory vs int64)
+            idx_lo = (blk & 0x0F).to(torch.int32)
+            idx_hi = (blk >> 4).to(torch.int32)
 
             sub = out[r0:r1]
             sub[:, 0::2] = lut[idx_lo]

--- a/tritonllm/triton_kernels/target_info.py
+++ b/tritonllm/triton_kernels/target_info.py
@@ -93,12 +93,15 @@ def num_sms():
 
 @constexpr_function
 def has_tma_gather():
+    # TMA gather works on both data center Blackwell (sm_100x) and consumer
+    # Blackwell (sm_120a / RTX 5090).  Verified on RTX 5090 hardware.
     return cuda_capability_geq(10, 0)
 
 
 @constexpr_function
 def has_tma_scatter():
-    # Same limitation as TMA gather: requires data center Blackwell (sm_100x).
+    # TMA scatter with .shared::cluster requires data center Blackwell (sm_100x).
+    # Not available on consumer Blackwell sm_120a (RTX 5090).
     return cuda_capability_geq(10, 0) and not cuda_capability_eq(12, 0)
 
 


### PR DESCRIPTION
## Summary

Adds CPU offload for MoE expert weights, enabling the GPT-OSS 120B model to run on consumer GPUs (RTX 5090 / 32 GB VRAM) at **4.5 TPS** decode speed.

The model has 128 experts × 36 layers (~60 GB total). Expert weights are stored pageable on CPU and a shared set of 128 GPU slots is filled on-demand as each layer routes to 4 of 128 experts.

## Architecture

```
  CPU (754 GB RAM)                          GPU (32 GB VRAM)
  ┌─────────────────┐                      ┌─────────────────┐
  │ expert_cache.cpu │  ──CPU→GPU copy──→  │ 128 shared slots│ ← matmul reads
  │ [layer][expert]  │     (~8 GB/s)       │ gpu_w1, gpu_w2  │    from here
  │  w1,w2,b1,b2     │                     │ gpu_b1, gpu_b2  │
  └─────────────────┘                      └────────┬────────┘
                                                    │
                                          ┌─────────▼────────┐
                                          │  Victim Cache    │
                                          │  120 slots (1.7G)│
                                          │  LRU eviction    │
                                          │  D2D restore     │
                                          │  (~900 GB/s)     │
                                          └──────────────────┘
```

**ExpertCache** (`tritonllm/gpt_oss/triton/expert_cache.py`):
- Per-layer, per-expert CPU storage with raw torch.Tensor slices
- 128 shared GPU buffers (one slot per expert ID) reused across all layers
- **Victim cache**: manually-managed contiguous GPU buffer that saves expert data evicted from shared slots and restores it via fast D2D copy (~900 GB/s) on reuse. 120 slots × ~14 MB = 1.7 GB, LRU eviction.
- **gpu_layer tracking**: CPU-side array tracking which layer's data resides in each GPU slot. When the same layer reuses a slot on the next token and no other layer has overwritten it, the CPU→GPU copy is skipped entirely (free, ~15% hit rate).
- **GPU hot-layer cache**: keeps the first ~3 layers' experts permanently on GPU (limited by free VRAM).
- **CUDA Graphs**: per-layer route_graph + decode_graph captured once, replayed for every layer/token.

## Performance on RTX 5090

| Configuration                   | TPS    | Expert hit rate |
|---------------------------------|--------|----------------|
| CPU offload, gpu_layer only     | ~3.02  | ~15%           |
| CPU offload + victim cache      | **4.50** | 50–65%       |

Victim cache reduces PCIe traffic by ~50% after warmup.

## Usage

```bash
python examples/bench_chat.py 120b --cpu-offload --prompt "Hello"
python examples/only_output.py 120b --cpu-offload
```

## Environment Variables

| Variable         | Default | Description                         |
|------------------|---------|-------------------------------------|
| `CPU_OFFLOAD`    | `"0"`   | Enable CPU offload for MoE experts  |
| `PRINT_HIT_RATE` | `"0"`   | Print per-token cache hit rate      |
| `CUDA_GRAPH`     | `"1"`   | Enable per-layer CUDA Graphs        |
| `VICTIM_CACHE`   | `"1"`   | Enable victim cache                 |
| `MOE_BLOCK_K`    | dynamic | Override MoE matmul block size      |

## Files Changed

| File | Description |
|------|-------------|
| `tritonllm/gpt_oss/triton/expert_cache.py` | NEW: ExpertCache with victim cache, gpu_layer, CUDA graphs |
| `tritonllm/gpt_oss/triton/model.py` | CPU offload loading, `_forward_decode_offload`, FP8 unembed/QKV |
| `tritonllm/gpt_oss/triton/moe.py` | Decode-specialized MoE kernels, dynamic MOE_BLOCK_K |
| `tritonllm/triton_kernels/target_info.py` | Clarify TMA gather/scatter support on consumer Blackwell |
| `examples/bench_chat.py` | Add `--prompt` / `--cpu-offload` flags |
| `tritonllm/gpt_oss/bench.py` | CPU offload integration |
