### PR TITLE
docs: fix documented context default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | `--show-browser-results` | Show fetched browser results in the output. Default: `False`. |
 | `-p, --python` | Enable Python execution tool (run Python snippets). Default: `False`. |
 | `--developer-message DEVELOPER_MESSAGE` | Provide a developer/system message that influences the model’s behavior. |
-| `-c CONTEXT, --context CONTEXT` | Maximum context length (tokens). Default: `8192`. |
+| `-c CONTEXT, --context CONTEXT` | Maximum context length (tokens). Default: `131072`. |
 | `--raw` | Raw mode. Disable Harmony encoding and render plain output. Default: `False`. |
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -85,7 +85,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | `--show-browser-results` | 在输出中显示抓取的浏览器结果。默认：`False`。 |
 | `-p, --python` | 启用 Python 执行工具（允许模型运行 Python 代码片段）。默认：`False`。 |
 | `--developer-message DEVELOPER_MESSAGE` | 提供开发者/系统消息以影响模型行为。 |
-| `-c CONTEXT, --context CONTEXT` | 最大上下文长度（Token 数）。默认：`8192`。 |
+| `-c CONTEXT, --context CONTEXT` | 最大上下文长度（Token 数）。默认：`131072`。 |
 | `--raw` | 原始模式，禁用 Harmony 编码并输出纯文本。默认：`False`。 |
 
 


### PR DESCRIPTION
fixes a README / CLI default mismatch.

`tritonllm --help` is generated from `get_parser_args()`, where `--context` defaults to `131072`, but both README files documented the default as `8192`.

This updates `README.md` and `README.zh.md` to match the current CLI behavior.
