### PR TITLE
docs: list missing CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ tritonllm --help
 ### Usage
 
 ```shell
-usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [-p]
+usage: tritonllm [-h] [--version] [-r REASONING_EFFORT] [-a] [-b]
+                 [--show-browser-results] [-p]
                  [--developer-message DEVELOPER_MESSAGE] [-c CONTEXT] [--raw]
-                 [FILE]
+                 [--cpu-offload] [FILE]
 
 ```
 
@@ -72,6 +73,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | Option | Description |
 |--------|-------------|
 | `-h, --help` | Show this help message and exit. |
+| `--version` | Show the installed `tritonllm` version and exit. |
 | `-r REASONING_EFFORT, --reasoning-effort REASONING_EFFORT` | Set reasoning effort level (`low` / `medium` / `high`). Default: `high`. |
 | `-a, --apply-patch` | Make the internal `apply_patch` function available to the model. Default: `False`. |
 | `-b, --browser` | Enable browser tool so the model can fetch web content. Default: `False`. |
@@ -80,6 +82,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | `--developer-message DEVELOPER_MESSAGE` | Provide a developer/system message that influences the model’s behavior. |
 | `-c CONTEXT, --context CONTEXT` | Maximum context length (tokens). Default: `8192`. |
 | `--raw` | Raw mode. Disable Harmony encoding and render plain output. Default: `False`. |
+| `--cpu-offload` | Enable CPU offload for MoE expert weights. Default: `None`. |
 
 
 ## Install from source

--- a/README.zh.md
+++ b/README.zh.md
@@ -63,9 +63,10 @@ tritonllm --help
 ### 使用方法
 
 ```
-usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [-p]
+usage: tritonllm [-h] [--version] [-r REASONING_EFFORT] [-a] [-b]
+                 [--show-browser-results] [-p]
                  [--developer-message DEVELOPER_MESSAGE] [-c CONTEXT] [--raw]
-                 [FILE]
+                 [--cpu-offload] [FILE]
 ```
 
 ## 位置参数
@@ -79,6 +80,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | 参数 | 说明 |
 |------|------|
 | `-h, --help` | 显示帮助信息并退出。 |
+| `--version` | 显示已安装的 `tritonllm` 版本并退出。 |
 | `-r REASONING_EFFORT, --reasoning-effort REASONING_EFFORT` | 设置推理努力等级（`low` / `medium` / `high`）。默认：`high`。 |
 | `-a, --apply-patch` | 使模型可使用内部 `apply_patch` 函数。默认：`False`。 |
 | `-b, --browser` | 启用浏览器工具，让模型可以抓取网页内容。默认：`False`。 |
@@ -87,6 +89,7 @@ usage: tritonllm [-h] [-r REASONING_EFFORT] [-a] [-b] [--show-browser-results] [
 | `--developer-message DEVELOPER_MESSAGE` | 提供开发者/系统消息以影响模型行为。 |
 | `-c CONTEXT, --context CONTEXT` | 最大上下文长度（Token 数）。默认：`8192`。 |
 | `--raw` | 原始模式，禁用 Harmony 编码并输出纯文本。默认：`False`。 |
+| `--cpu-offload` | 为 MoE expert 权重启用 CPU offload。默认：`None`。 |
 
 
 ## 源码安装


### PR DESCRIPTION
The CLI README examples drifted from the parser in `tritonllm/gpt_oss/chat.py`.

Failure mechanism:
- the parser already exposes `--version` and `--cpu-offload`
- both `README.md` and `README.zh.md` omitted those options from the usage block and option table
- users reading the docs could miss a supported switch or assume the help output was wrong

Semantic change:
- add `--version` and `--cpu-offload` to the documented usage synopsis
- add matching English and Chinese option-table entries
- keep the existing documented `--context` default untouched here to avoid overlapping with the already-open draft PR #42

Testing:
- source verification against `tritonllm/gpt_oss/chat.py:326-399`
- local import-based `--help` execution is currently blocked in this checkout because `tritonllm.__init__` imports `triton` eagerly and the dependency is not installed in this environment